### PR TITLE
Feat/typography: Typography 컴포넌트 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,11 +4,11 @@
     "es2021": true
   },
   "extends": [
+    "plugin:import/typescript",
+    "plugin:import/recommended",
     "eslint:recommended",
     "plugin:react/recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:import/typescript",
-    "plugin:import/recommended"
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -33,6 +33,7 @@
     "no-nested-ternary": "error",
     "eqeqeq": "error",
     "no-console": "warn",
+    "import/named": "off",
     "import/no-unresolved": "off",
     "import/order": [
       "error",

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,3 +1,8 @@
+const viteTsconfig = require('vite-tsconfig-paths');
+const tsconfigPaths = viteTsconfig.default;
+
+const { mergeConfig } = require('vite');
+
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -11,5 +16,10 @@ module.exports = {
   },
   features: {
     storyStoreV7: true,
+  },
+  async viteFinal(config) {
+    return mergeConfig(config, {
+      plugins: [tsconfigPaths()],
+    });
   },
 };

--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -1,13 +1,13 @@
 module.exports = {
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-interactions",
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
   ],
-  framework: "@storybook/react",
+  framework: '@storybook/react',
   core: {
-    builder: "@storybook/builder-vite",
+    builder: '@storybook/builder-vite',
   },
   features: {
     storyStoreV7: true,

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "stylelint-config-property-sort-order-smacss": "^9.0.0",
     "stylelint-config-recommended-scss": "^9.0.0",
     "typescript": "^4.9.3",
-    "vite": "^4.1.0"
+    "vite": "^4.1.0",
+    "vite-tsconfig-paths": "^4.0.5"
   }
 }

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,0 +1,47 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Typography from '.';
+
+export default {
+  title: 'Typography',
+  component: Typography,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Typography>;
+
+const DUMMY_TEXT = '안녕하세요. 콜드스터디 디자인 시스템입니다. 🧊';
+
+const Template: ComponentStory<typeof Typography> = (args) => (
+  <Typography {...args}>{DUMMY_TEXT}</Typography>
+);
+
+export const Title1 = Template.bind({});
+Title1.args = {
+  variant: 'title1',
+};
+
+export const Title2 = Template.bind({});
+Title2.args = {
+  variant: 'title2',
+};
+
+export const Subtitle1 = Template.bind({});
+Subtitle1.args = {
+  variant: 'subtitle1',
+};
+
+export const Subtitle2 = Template.bind({});
+Subtitle2.args = {
+  variant: 'subtitle2',
+};
+
+export const Body = Template.bind({});
+Body.args = {
+  variant: 'body',
+};
+
+export const Desc = Template.bind({});
+Desc.args = {
+  variant: 'desc',
+};

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,0 +1,43 @@
+import { VARIANT, FONT_SIZE, FONT_WEIGHT } from '@constants/typography';
+import { css, jsx } from '@emotion/react';
+
+type TypographyVariant = `${VARIANT}`;
+
+interface TypographyProps {
+  variant: TypographyVariant;
+  children: string;
+}
+
+function Typography({ variant, children }: TypographyProps) {
+  let typography: string;
+
+  switch (variant) {
+    case VARIANT.TITLE1:
+      typography = 'h1';
+      break;
+    case VARIANT.TITLE2:
+      typography = 'h2';
+      break;
+    case VARIANT.SUBTITLE1:
+      typography = 'h3';
+      break;
+    case VARIANT.SUBTITLE2:
+      typography = 'h4';
+      break;
+    default:
+      typography = 'p';
+  }
+
+  return jsx(
+    typography,
+    {
+      css: css`
+        font-size: ${FONT_SIZE[variant]};
+        font-weight: ${FONT_WEIGHT[variant]};
+      `,
+    },
+    children,
+  );
+}
+
+export default Typography;

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -8,25 +8,23 @@ interface TypographyProps {
   children: string;
 }
 
-function Typography({ variant, children }: TypographyProps) {
-  let typography: string;
-
+function getTypography(variant: TypographyVariant): string {
   switch (variant) {
     case VARIANT.TITLE1:
-      typography = 'h1';
-      break;
+      return 'h1';
     case VARIANT.TITLE2:
-      typography = 'h2';
-      break;
+      return 'h2';
     case VARIANT.SUBTITLE1:
-      typography = 'h3';
-      break;
+      return 'h3';
     case VARIANT.SUBTITLE2:
-      typography = 'h4';
-      break;
+      return 'h4';
     default:
-      typography = 'p';
+      return 'p';
   }
+}
+
+function Typography({ variant, children }: TypographyProps) {
+  const typography = getTypography(variant);
 
   return jsx(
     typography,

--- a/src/constants/typography.ts
+++ b/src/constants/typography.ts
@@ -1,0 +1,26 @@
+export enum VARIANT {
+  TITLE1 = 'title1',
+  TITLE2 = 'title2',
+  SUBTITLE1 = 'subtitle1',
+  SUBTITLE2 = 'subtitle2',
+  BODY = 'body',
+  DESC = 'desc',
+}
+
+export const FONT_SIZE: Record<VARIANT, string> = {
+  [VARIANT.TITLE1]: '3rem',
+  [VARIANT.TITLE2]: '2.25rem',
+  [VARIANT.SUBTITLE1]: '1.5rem',
+  [VARIANT.SUBTITLE2]: '1.25rem',
+  [VARIANT.BODY]: '1rem',
+  [VARIANT.DESC]: '0.75rem',
+};
+
+export const FONT_WEIGHT: Record<VARIANT, number> = {
+  [VARIANT.TITLE1]: 900,
+  [VARIANT.TITLE2]: 900,
+  [VARIANT.SUBTITLE1]: 700,
+  [VARIANT.SUBTITLE2]: 700,
+  [VARIANT.BODY]: 400,
+  [VARIANT.DESC]: 400,
+};

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -4,6 +4,7 @@
     "paths": {
       "@src/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
+      "@constants/*": ["./src/constants/*"],
       "@styles/*": ["./src/styles/*"]
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,16 +2,21 @@ import { resolve } from 'path';
 
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   resolve: {
     alias: [
       { find: '@src', replacement: resolve(__dirname, './src') },
       {
         find: '@components',
         replacement: resolve(__dirname, './src/components'),
+      },
+      {
+        find: '@constants',
+        replacement: resolve(__dirname, './src/constants'),
       },
       {
         find: '@styles',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -6278,6 +6278,11 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -10569,6 +10574,11 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+tsconfck@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tsconfck/-/tsconfck-2.0.2.tgz#860a488f9acd024a85b2db458888410009b5383d"
+  integrity sha512-H3DWlwKpow+GpVLm/2cpmok72pwRr1YFROV3YzAmvzfGFiC1zEM/mc9b7+1XnrxuXtEbhJ7xUSIqjPFbedp7aQ==
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -10982,6 +10992,15 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+vite-tsconfig-paths@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/vite-tsconfig-paths/-/vite-tsconfig-paths-4.0.5.tgz#c7c54e2cf7ccc5e600db565cecd7b368a1fa8889"
+  integrity sha512-/L/eHwySFYjwxoYt1WRJniuK/jPv+WGwgRGBYx3leciR5wBeqntQpUE6Js6+TJemChc+ter7fDBKieyEWDx4yQ==
+  dependencies:
+    debug "^4.1.1"
+    globrex "^0.1.2"
+    tsconfck "^2.0.1"
 
 vite@^4.1.0:
   version "4.1.1"


### PR DESCRIPTION
## 🤠 개요

- Closes #1 
- Typography 컴포넌트를 추가합니다.

## 💫 설명

- 아래와 같은 `variant`를 props로 전달합니다.

```ts
enum VARIANT {
  TITLE1 = 'title1',
  TITLE2 = 'title2',
  SUBTITLE1 = 'subtitle1',
  SUBTITLE2 = 'subtitle2',
  BODY = 'body',
  DESC = 'desc',
}
```

## 📷 스크린샷


https://user-images.githubusercontent.com/63814960/218325049-011a4fb0-5aed-451d-b8a1-0c3eed2af429.mov


## 📖 참고 자료

`Emotion.jsx`
- [https://emotion.sh/docs/typescript\#with-the-old-jsx-transform](https://emotion.sh/docs/typescript/#with-the-old-jsx-transform)

`TypeScript 문법`
- [https://typescript-kr.github.io/pages/utility-types.html\#partialt](https://typescript-kr.github.io/pages/utility-types.html/#partialt)
- https://bobbyhadz.com/blog/typescript-convert-enum-to-union

`storybook Failed to fetch dynamically imported module: 에러`
- https://github.com/storybookjs/storybook/issues/18891