### PR TITLE
Feat: Badge 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
     "@react-icons/all-files": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,49 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Badge from '.';
+
+export default {
+  title: 'Badge',
+  component: Badge,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Badge>;
+
+const DUMMY_STRING = 'Javascript';
+
+const Template: ComponentStory<typeof Badge> = (args) => (
+  <Badge {...args}>{DUMMY_STRING}</Badge>
+);
+
+export const FilledLargeBadge = Template.bind({});
+FilledLargeBadge.args = {
+  fill: true,
+  size: 'large',
+  outline: true,
+};
+
+export const FilledSmallBadge = Template.bind({});
+FilledSmallBadge.args = {
+  fill: true,
+  outline: true,
+};
+
+export const LargeBadge = Template.bind({});
+LargeBadge.args = {
+  size: 'large',
+  outline: true,
+};
+
+export const SmallBadge = Template.bind({});
+SmallBadge.args = {
+  outline: true,
+};
+
+export const WithoutOutlineLargeBadge = Template.bind({});
+WithoutOutlineLargeBadge.args = {
+  size: 'large',
+};
+
+export const WithoutOutlineSmallBadge = Template.bind({});
+WithoutOutlineSmallBadge.args = {};

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,0 +1,49 @@
+import Center from '@components/Center';
+import Typography from '@components/Typography';
+import styled from '@emotion/styled';
+
+type BadgeSize = 'large' | 'small';
+
+interface BadgeProps {
+  children: string;
+  size?: BadgeSize;
+  outline?: boolean;
+  color?: string;
+  fill?: boolean;
+}
+
+function Badge({
+  children,
+  size = 'small',
+  outline = false,
+  color = '#1493FF',
+  fill = false,
+}: BadgeProps) {
+  return (
+    <BadgeContainer {...{ outline, color, fill }}>
+      <Center>
+        <Typography variant={size === 'large' ? 'body' : 'desc'}>
+          {children}
+        </Typography>
+      </Center>
+    </BadgeContainer>
+  );
+}
+
+export default Badge;
+
+const BadgeContainer = styled.div<Omit<BadgeProps, 'children' | 'size'>>(
+  ({ outline, color, fill }) => ({
+    width: 'fit-content',
+    padding: '8px 12px',
+    borderRadius: 30,
+    border: outline ? `1px solid ${color}` : 'none',
+    color: fill ? 'white' : color,
+    backgroundColor: fill ? color : 'transparent',
+
+    ':hover': {
+      color: fill ? color : 'white',
+      backgroundColor: fill ? 'transparent' : color,
+    },
+  }),
+);

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -30,6 +30,7 @@ function Typography({ variant, children }: TypographyProps) {
     typography,
     {
       css: css`
+        margin: 0;
         font-size: ${FONT_SIZE[variant]};
         font-weight: ${FONT_WEIGHT[variant]};
       `,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
+"@emotion/is-prop-valid@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+
 "@emotion/memoize@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.0.tgz#f580f9beb67176fa57aae70b08ed510e1b18980f"
@@ -1281,6 +1288,18 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.1.tgz#0767e0305230e894897cadb6c8df2c51e61a6c2c"
   integrity sha512-zxRBwl93sHMsOj4zs+OslQKg/uhF38MB+OMKoCrVuS0nyTkqnau+BM3WGEoOptg9Oz45T/aIGs1qbVAsEFo3nA==
+
+"@emotion/styled@^11.10.5":
+  version "11.10.5"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.5.tgz#1fe7bf941b0909802cb826457e362444e7e96a79"
+  integrity sha512-8EP6dD7dMkdku2foLoruPCNkRevzdcBaY6q0l0OsbyJK+x8D9HWjX27ARiSIKNF634hY9Zdoedh8bJCiva8yZw==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.5"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@emotion/serialize" "^1.1.1"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
 
 "@emotion/unitless@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Resolves: #5
- `feat/center` 브랜치에서 새 브랜치 파서 지금은 `feat/center`로 PR 보내요

## 💫 설명

<!--

- 현재 Pr 설명

-->

- Badge 컴포넌트에서 `Typo`랑 `Center`를 쓰게 돼서 Badge를 감싸는 컨테이너도 추상화 레벨을 맞춰주려고 `styled` 로 했어요.
  - `@emotion/styled` 설치했슴다

- Typography에 margin이 있어서 Badge가 뚱뚱해졌어요.
  - Typography에서 margin 제거했어요.
  - 나중에 이거 `Global style`따로 빼서 storybook에 설정해주고 패키지에도 같이 넣어서 배포하면 될것같아요.
  - [참고](https://velog.io/@kimhyo_0218/Storybook-emotion%EC%9C%BC%EB%A1%9C-storybook-%EA%B8%80%EB%A1%9C%EB%B2%8C-%EC%8A%A4%ED%83%80%EC%9D%BC-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0-reset-css)

- color 상수를 따로 빼야하는데 이건 다른 이슈 파서 할게요.
  - 그래서 일단 color는 string으로 받게 했어요
 
## 📷 스크린샷 (Optional)
<img width="450" alt="스크린샷 2023-02-13 오후 2 57 13" src="https://user-images.githubusercontent.com/65100540/218382673-961ba88b-22ee-47b2-aade-5ff43b6342ae.png">

<img width="448" alt="스크린샷 2023-02-13 오후 2 57 21" src="https://user-images.githubusercontent.com/65100540/218382695-0f997b2a-cc86-487a-b53b-bc9253890ca3.png">
