### PR TITLE
Feat/util-types: DefaultProps 유틸리티 타입 추가

### DIFF
--- a/src/utils/types/DefaultProps.ts
+++ b/src/utils/types/DefaultProps.ts
@@ -1,0 +1,7 @@
+import { Interpolation, Theme } from '@emotion/react';
+import { ClassAttributes, HTMLAttributes } from 'react';
+
+export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
+  HTMLAttributes<T> & {
+    css?: Interpolation<Theme>;
+  };

--- a/src/utils/types/DefaultPropsWithChildren.ts
+++ b/src/utils/types/DefaultPropsWithChildren.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+
+import { DefaultProps } from './DefaultProps';
+
+export type DefaultPropsWithChildren<T extends HTMLElement> =
+  DefaultProps<T> & {
+    children: ReactNode;
+  };

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -5,7 +5,9 @@
       "@src/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
-      "@styles/*": ["./src/styles/*"]
+      "@styles/*": ["./src/styles/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@util-types/*": ["./src/utils/types/*"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,14 @@ export default defineConfig({
         find: '@styles',
         replacement: resolve(__dirname, './src/styles'),
       },
+      {
+        find: '@utils',
+        replacement: resolve(__dirname, './src/utils'),
+      },
+      {
+        find: '@util-types',
+        replacement: resolve(__dirname, './src/utils/types'),
+      },
     ],
   },
 });


### PR DESCRIPTION
## 🤠 개요

- See also #11 
- `Container` 컴포넌트를 구현하다보니 유즈케이스 없이 추상화하기가 까다로웠습니다.
- 확장성 있는 props를 통해 기존 속성이나 추가 스타일을 사용할 수 있으면 좋겠다고 생각했고, 이런 경우 사용할 수 있는 유틸리티 타입들을 만들었습니다.

## 💫 설명

```ts
import { Interpolation, Theme } from '@emotion/react';
import { ClassAttributes, HTMLAttributes } from 'react';

export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
  HTMLAttributes<T> & {
    css?: Interpolation<Theme>;
  };
```

`DefaultProps<T>`: HTMLElement T 리액트 노드가 가질 수 있는 속성들과 emotion의 css를 포함

```ts
import { ReactNode } from 'react';

import { DefaultProps } from './DefaultProps';

export type DefaultPropsWithChildren<T extends HTMLElement> =
  DefaultProps<T> & {
    children: ReactNode;
  };
```

`DefaultPropsWithChildren<T>`: children을 필수로 가지는 DefaultProps

<br />

그리고 이런식으로 사용해요.

```ts
const Container = ({
  children,
  css: style,
  ...props
}: DefaultPropsWithChildren<HTMLDivElement>) => {
  return (
    <div
      css={[
        css`
          max-width: 100%;
          width: 100%;
          height: 100%;
        `,
        style,
      ]}
      {...props}
    >
      {children}
    </div>
  );
};
```
