### PR TITLE
Feat/layout: Container, Flexbox, List 컴포넌트 구현

### DIFF
--- a/src/components/Center/index.tsx
+++ b/src/components/Center/index.tsx
@@ -1,22 +1,22 @@
+import Flexbox from '@components/Flexbox';
 import { css } from '@emotion/react';
-import React from 'react';
+import { ReactNode } from 'react';
 
 interface CenterProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 function Center({ children }: CenterProps) {
   return (
-    <div
+    <Flexbox
+      alignItems="center"
+      justifyContent="center"
       css={css`
-        display: flex;
-        justify-content: center;
-        align-items: center;
         text-align: center;
       `}
     >
       {children}
-    </div>
+    </Flexbox>
   );
 }
 

--- a/src/components/Container/Container.stories.tsx
+++ b/src/components/Container/Container.stories.tsx
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Container from '.';
+
+export default {
+  title: 'Container',
+  component: Container,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Container>;
+
+const Template: ComponentStory<typeof Container> = (args) => (
+  <Container {...args} />
+);
+
+export const BasicContainer = Template.bind({});
+BasicContainer.args = {
+  css: css`
+    width: 300px;
+    height: 300px;
+  `,
+  children: (
+    <Container
+      css={css`
+        background-color: pink;
+      `}
+    >
+      <p>빈 공간이 많은 컨테이너</p>
+    </Container>
+  ),
+};
+
+export const ScrollContainer = Template.bind({});
+ScrollContainer.args = {
+  overflowY: 'scroll',
+  css: css`
+    height: 100px;
+  `,
+  children: (
+    <div style={{ height: '300px' }}>Container보다 세로로 더 긴 컨텐츠</div>
+  ),
+};

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+import { CSSProperties } from 'react';
 
 interface ContainerProps extends DefaultPropsWithChildren<HTMLDivElement> {
-  overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto';
-  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto';
+  overflowX?: CSSProperties['overflowX'];
+  overflowY?: CSSProperties['overflowY'];
 }
 
 const Container = ({

--- a/src/components/Container/index.tsx
+++ b/src/components/Container/index.tsx
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react';
+import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+
+interface ContainerProps extends DefaultPropsWithChildren<HTMLDivElement> {
+  overflowX?: 'visible' | 'hidden' | 'scroll' | 'auto';
+  overflowY?: 'visible' | 'hidden' | 'scroll' | 'auto';
+}
+
+const Container = ({
+  children,
+  css: style,
+  overflowX = 'hidden',
+  overflowY = 'hidden',
+  ...props
+}: ContainerProps) => {
+  return (
+    <div
+      css={[
+        css`
+          max-width: 100%;
+          width: 100%;
+          height: 100%;
+          overflow-x: ${overflowX};
+          overflow-y: ${overflowY};
+        `,
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Container;

--- a/src/components/Flexbox/Flexbox.stories.tsx
+++ b/src/components/Flexbox/Flexbox.stories.tsx
@@ -26,7 +26,7 @@ RowFlexbox.args = {
 
 export const SpaceBetweenFlexbox = Template.bind({});
 SpaceBetweenFlexbox.args = {
-  justify: 'space-between',
+  justifyContent: 'space-between',
   gap: '0rem',
   css: css`
     width: 300px;

--- a/src/components/Flexbox/Flexbox.stories.tsx
+++ b/src/components/Flexbox/Flexbox.stories.tsx
@@ -11,13 +11,23 @@ export default {
   },
 } as ComponentMeta<typeof Flexbox>;
 
-const Template: ComponentStory<typeof Flexbox> = (args) => (
-  <Flexbox {...args}>
-    <p>1</p>
-    <p>2</p>
-    <p>3</p>
-  </Flexbox>
-);
+const Template: ComponentStory<typeof Flexbox> = (args) => {
+  const commonStyle = css`
+    width: 300px;
+    background-color: #dfdfdf;
+  `;
+
+  return (
+    <Flexbox css={commonStyle} {...args}>
+      <p>1</p>
+      <p>2</p>
+      <p>3</p>
+      <p>4</p>
+      <p>5</p>
+      <p>6</p>
+    </Flexbox>
+  );
+};
 
 export const RowFlexbox = Template.bind({});
 RowFlexbox.args = {
@@ -28,8 +38,16 @@ export const SpaceBetweenFlexbox = Template.bind({});
 SpaceBetweenFlexbox.args = {
   justifyContent: 'space-between',
   gap: '0rem',
+};
+
+export const MultiLineFlexbox = Template.bind({});
+MultiLineFlexbox.args = {
+  wrap: 'wrap',
+  alignContent: 'center',
   css: css`
-    width: 300px;
+    width: 100px;
+    height: 300px;
+    background-color: #dfdfdf;
   `,
 };
 

--- a/src/components/Flexbox/Flexbox.stories.tsx
+++ b/src/components/Flexbox/Flexbox.stories.tsx
@@ -1,0 +1,39 @@
+import { css } from '@emotion/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Flexbox from '.';
+
+export default {
+  title: 'Flexbox',
+  component: Flexbox,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Flexbox>;
+
+const Template: ComponentStory<typeof Flexbox> = (args) => (
+  <Flexbox {...args}>
+    <p>1</p>
+    <p>2</p>
+    <p>3</p>
+  </Flexbox>
+);
+
+export const RowFlexbox = Template.bind({});
+RowFlexbox.args = {
+  direction: 'row',
+};
+
+export const SpaceBetweenFlexbox = Template.bind({});
+SpaceBetweenFlexbox.args = {
+  justify: 'space-between',
+  gap: '0rem',
+  css: css`
+    width: 300px;
+  `,
+};
+
+export const ColumnFlexbox = Template.bind({});
+ColumnFlexbox.args = {
+  direction: 'column',
+};

--- a/src/components/Flexbox/index.tsx
+++ b/src/components/Flexbox/index.tsx
@@ -4,8 +4,8 @@ import { CSSProperties } from 'react';
 
 interface FlexboxProps extends DefaultPropsWithChildren<HTMLDivElement> {
   direction?: CSSProperties['flexDirection'];
-  align?: CSSProperties['alignItems'];
-  justify?: CSSProperties['justifyContent'];
+  alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
   gap?: CSSProperties['gap'];
 }
 
@@ -13,8 +13,8 @@ const Flexbox = ({
   children,
   css: style,
   direction = 'row',
-  align = 'center',
-  justify = 'center',
+  alignItems = 'center',
+  justifyContent = 'center',
   gap = '1rem',
   ...props
 }: FlexboxProps) => {
@@ -24,8 +24,8 @@ const Flexbox = ({
         css`
           display: flex;
           flex-direction: ${direction};
-          align-items: ${align};
-          justify-content: ${justify};
+          align-items: ${alignItems};
+          justify-content: ${justifyContent};
           gap: ${gap};
         `,
         style,

--- a/src/components/Flexbox/index.tsx
+++ b/src/components/Flexbox/index.tsx
@@ -4,6 +4,8 @@ import { CSSProperties } from 'react';
 
 interface FlexboxProps extends DefaultPropsWithChildren<HTMLDivElement> {
   direction?: CSSProperties['flexDirection'];
+  wrap?: CSSProperties['flexWrap'];
+  alignContent?: CSSProperties['alignContent'];
   alignItems?: CSSProperties['alignItems'];
   justifyContent?: CSSProperties['justifyContent'];
   gap?: CSSProperties['gap'];
@@ -13,6 +15,8 @@ const Flexbox = ({
   children,
   css: style,
   direction = 'row',
+  wrap = 'nowrap',
+  alignContent = 'normal',
   alignItems = 'center',
   justifyContent = 'center',
   gap = '1rem',
@@ -24,6 +28,8 @@ const Flexbox = ({
         css`
           display: flex;
           flex-direction: ${direction};
+          flex-wrap: ${wrap};
+          align-content: ${alignContent};
           align-items: ${alignItems};
           justify-content: ${justifyContent};
           gap: ${gap};

--- a/src/components/Flexbox/index.tsx
+++ b/src/components/Flexbox/index.tsx
@@ -1,15 +1,9 @@
 import { css } from '@emotion/react';
 import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
-import { CSSProperties } from 'react';
+import { FlexContainerProps } from '@util-types/FlexContainerProps';
 
-interface FlexboxProps extends DefaultPropsWithChildren<HTMLDivElement> {
-  direction?: CSSProperties['flexDirection'];
-  wrap?: CSSProperties['flexWrap'];
-  alignContent?: CSSProperties['alignContent'];
-  alignItems?: CSSProperties['alignItems'];
-  justifyContent?: CSSProperties['justifyContent'];
-  gap?: CSSProperties['gap'];
-}
+type FlexboxProps = DefaultPropsWithChildren<HTMLDivElement> &
+  FlexContainerProps;
 
 const Flexbox = ({
   children,

--- a/src/components/Flexbox/index.tsx
+++ b/src/components/Flexbox/index.tsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+import { CSSProperties } from 'react';
+
+interface FlexboxProps extends DefaultPropsWithChildren<HTMLDivElement> {
+  direction?: CSSProperties['flexDirection'];
+  align?: CSSProperties['alignItems'];
+  justify?: CSSProperties['justifyContent'];
+  gap?: CSSProperties['gap'];
+}
+
+const Flexbox = ({
+  children,
+  css: style,
+  direction = 'row',
+  align = 'center',
+  justify = 'center',
+  gap = '1rem',
+  ...props
+}: FlexboxProps) => {
+  return (
+    <div
+      css={[
+        css`
+          display: flex;
+          flex-direction: ${direction};
+          align-items: ${align};
+          justify-content: ${justify};
+          gap: ${gap};
+        `,
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Flexbox;

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import List from '.';
+
+export default {
+  title: 'List',
+  component: List,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof List>;
+
+const Template: ComponentStory<typeof List> = (args) => {
+  return (
+    <List {...args}>
+      <li>1</li>
+      <li>2</li>
+      <li>3</li>
+      <li>4</li>
+      <li>5</li>
+      <li>6</li>
+    </List>
+  );
+};
+
+const commonStyle = css`
+  width: 300px;
+  background-color: #dfdfdf;
+`;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  css: commonStyle,
+};
+
+export const MultiLine = Template.bind({});
+MultiLine.args = {
+  wrap: 'wrap',
+  alignContent: 'space-around',
+  css: [
+    commonStyle,
+    css`
+      height: 100px;
+    `,
+  ],
+};

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,0 +1,40 @@
+import { css } from '@emotion/react';
+import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+import { FlexContainerProps } from '@util-types/FlexContainerProps';
+
+type ListProps = DefaultPropsWithChildren<HTMLUListElement> &
+  FlexContainerProps;
+
+const List = ({
+  children,
+  css: style,
+  direction = 'column',
+  wrap = 'nowrap',
+  alignContent = 'normal',
+  alignItems = 'center',
+  justifyContent = 'center',
+  gap = '1rem',
+  ...props
+}: ListProps) => {
+  return (
+    <ul
+      css={[
+        css`
+          display: flex;
+          flex-direction: ${direction};
+          flex-wrap: ${wrap};
+          align-content: ${alignContent};
+          align-items: ${alignItems};
+          justify-content: ${justifyContent};
+          gap: ${gap};
+        `,
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </ul>
+  );
+};
+
+export default List;

--- a/src/utils/types/FlexContainerProps.ts
+++ b/src/utils/types/FlexContainerProps.ts
@@ -1,0 +1,10 @@
+import { CSSProperties } from 'react';
+
+export interface FlexContainerProps {
+  direction?: CSSProperties['flexDirection'];
+  wrap?: CSSProperties['flexWrap'];
+  alignContent?: CSSProperties['alignContent'];
+  alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
+  gap?: CSSProperties['gap'];
+}


### PR DESCRIPTION
## 🤠 개요

- Closes #11
- `Container`, `Flexbox` 두 가지 컴포넌트 구현했어요.

## 💫 설명

- Container, Flexbox, List 컴포넌트 완성했습니다.

- FlexboxProps에 `wrap`과 `alignContent`가 추가됐어요.
  - 이슈 댓글에 속성 관련 내용 간단하게 정리해뒀습니다.
  - https://github.com/c-h-w-h/cds/issues/11#issuecomment-1437738519

- 리뷰 반영했고 추가된 List 컴포넌트는 Flexbox에서 많이 달라진 부분이 없어 머지할게요!

- 이제보니 PR 쪼갤걸 그랬어요 ...

---

- #14 먼저 봐주세요!

- 기본 속성들은 들어가있되 필요한 경우 커스텀 가능하게 만들었어요. 스토리 쪽에서 어떻게 사용하는지 확인하실 수 있어요.

  - 기본 스타일이랑 props 어디까지 넣어야하는지 엄청 고민됐는데 지금도 고민돼요. 피드백 받고 고치고 싶어서 PR 올려요.

- 사실 금방 만들어질줄 알았는데 🫠 이런애들이 레퍼런스 많이 찾아보고 만들어야 하는 것 같아요.

  - 도훈님이 알려주셨는데 [Slash 라이브러리](https://slash.page/ko/libraries/react/emotion-utils/src/stack.i18n/) 최고에요!

### TBD

- 스크롤바 스타일링

<br />

## 📷 스크린샷

https://user-images.githubusercontent.com/63814960/220225440-a7f1f631-4b2b-4294-8890-2e2d3baed62c.mov




