### PR TITLE
Feat/image: Image 컴포넌트 구현

### DIFF
--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -13,73 +13,57 @@ export default {
 const DUMMY_SRC = 'https://picsum.photos/200/300';
 const DUMMY_ALT = '테스트 이미지를 설명';
 
-const Template: ComponentStory<typeof Image> = (args) => <Image {...args} />;
+const Template: ComponentStory<typeof Image> = (args) => (
+  <Image {...args} src={DUMMY_SRC} alt={DUMMY_ALT} />
+);
 
 export const SmallDefaultImage = Template.bind({});
 SmallDefaultImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'small',
 };
 
 export const SmallCircleImage = Template.bind({});
 SmallCircleImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'small',
   shape: 'circle',
 };
 
 export const SmallRoundedImage = Template.bind({});
 SmallRoundedImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'small',
   shape: 'rounded',
 };
 
 export const MediumDefaultImage = Template.bind({});
 MediumDefaultImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'medium',
 };
 
 export const MediumCircleImage = Template.bind({});
 MediumCircleImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'medium',
   shape: 'circle',
 };
 
 export const MediumRoundedImage = Template.bind({});
 MediumRoundedImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'medium',
   shape: 'rounded',
 };
 
 export const LargeDefaultImage = Template.bind({});
 LargeDefaultImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'large',
 };
 
 export const LargeCircleImage = Template.bind({});
 LargeCircleImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'large',
   shape: 'circle',
 };
 
 export const LargeRoundedImage = Template.bind({});
 LargeRoundedImage.args = {
-  src: DUMMY_SRC,
-  alt: DUMMY_ALT,
   size: 'large',
   shape: 'rounded',
 };

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -1,0 +1,85 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Image from '.';
+
+export default {
+  title: 'Image',
+  component: Image,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Image>;
+
+const DUMMY_SRC = 'https://picsum.photos/200/300';
+const DUMMY_ALT = '테스트 이미지를 설명';
+
+const Template: ComponentStory<typeof Image> = (args) => <Image {...args} />;
+
+export const SmallDefaultImage = Template.bind({});
+SmallDefaultImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'small',
+};
+
+export const SmallCircleImage = Template.bind({});
+SmallCircleImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'small',
+  shape: 'circle',
+};
+
+export const SmallRoundedImage = Template.bind({});
+SmallRoundedImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'small',
+  shape: 'rounded',
+};
+
+export const MediumDefaultImage = Template.bind({});
+MediumDefaultImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'medium',
+};
+
+export const MediumCircleImage = Template.bind({});
+MediumCircleImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'medium',
+  shape: 'circle',
+};
+
+export const MediumRoundedImage = Template.bind({});
+MediumRoundedImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'medium',
+  shape: 'rounded',
+};
+
+export const LargeDefaultImage = Template.bind({});
+LargeDefaultImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'large',
+};
+
+export const LargeCircleImage = Template.bind({});
+LargeCircleImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'large',
+  shape: 'circle',
+};
+
+export const LargeRoundedImage = Template.bind({});
+LargeRoundedImage.args = {
+  src: DUMMY_SRC,
+  alt: DUMMY_ALT,
+  size: 'large',
+  shape: 'rounded',
+};

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -5,11 +5,12 @@ import {
   IMAGE_SHAPE,
 } from '@constants/image';
 import styled from '@emotion/styled';
+import { DefaultProps } from '@src/utils/types/DefaultProps';
 
 type ImageSizeProps = `${ImageSizeVariant}`;
 type ImageShapeProps = `${ImageShapeVariant}`;
 
-interface ImageProps {
+interface ImageProps extends DefaultProps<HTMLImageElement> {
   src: string;
   alt: string;
   size: ImageSizeProps;

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,0 +1,29 @@
+import {
+  ImageSizeVariant,
+  ImageShapeVariant,
+  IMAGE_SIZE,
+  IMAGE_SHAPE,
+} from '@constants/image';
+import styled from '@emotion/styled';
+
+type ImageSizeProps = `${ImageSizeVariant}`;
+type ImageShapeProps = `${ImageShapeVariant}`;
+
+interface ImageProps {
+  src: string;
+  alt: string;
+  size: ImageSizeProps;
+  shape?: ImageShapeProps;
+}
+
+const Image = ({ src, alt, size, shape }: ImageProps) => {
+  return <ImageContainer {...{ src, alt, size, shape }} />;
+};
+
+export default Image;
+
+const ImageContainer = styled.img<ImageProps>`
+  width: ${({ size }) => IMAGE_SIZE[size]};
+  border-radius: ${({ shape }) => (shape ? IMAGE_SHAPE[shape] : 0)};
+  aspect-ratio: 1 / 1;
+`;

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -1,0 +1,21 @@
+export enum ImageSizeVariant {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}
+
+export enum ImageShapeVariant {
+  CIRCLE = 'circle',
+  ROUNDED = 'rounded',
+}
+
+export const IMAGE_SIZE: Record<ImageSizeVariant, string> = {
+  [ImageSizeVariant.SMALL]: '2rem',
+  [ImageSizeVariant.MEDIUM]: '3rem',
+  [ImageSizeVariant.LARGE]: '4rem',
+} as const;
+
+export const IMAGE_SHAPE: Record<ImageShapeVariant, string> = {
+  [ImageShapeVariant.CIRCLE]: '50%',
+  [ImageShapeVariant.ROUNDED]: '30px',
+};

--- a/src/utils/types/DefaultProps.ts
+++ b/src/utils/types/DefaultProps.ts
@@ -1,7 +1,8 @@
 import { Interpolation, Theme } from '@emotion/react';
-import { ClassAttributes, HTMLAttributes } from 'react';
+import { ClassAttributes, HTMLAttributes, ReactNode } from 'react';
 
 export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
   HTMLAttributes<T> & {
     css?: Interpolation<Theme>;
+    children?: ReactNode;
   };

--- a/src/utils/types/DefaultProps.ts
+++ b/src/utils/types/DefaultProps.ts
@@ -1,0 +1,7 @@
+import { Interpolation, Theme } from '@emotion/react';
+import { ClassAttributes, HTMLAttributes } from 'react';
+
+export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
+  HTMLAttributes<T> & {
+    css?: Interpolation<Theme>;
+  };

--- a/src/utils/types/DefaultPropsWithChildren.ts
+++ b/src/utils/types/DefaultPropsWithChildren.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react';
+
+import { DefaultProps } from './DefaultProps';
+
+export type DefaultPropsWithChildren<T extends HTMLElement> =
+  DefaultProps<T> & {
+    children: ReactNode;
+  };

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -5,7 +5,9 @@
       "@src/*": ["./src/*"],
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
-      "@styles/*": ["./src/styles/*"]
+      "@styles/*": ["./src/styles/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@util-types/*": ["./src/utils/types/*"]
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,14 @@ export default defineConfig({
         find: '@styles',
         replacement: resolve(__dirname, './src/styles'),
       },
+      {
+        find: '@utils',
+        replacement: resolve(__dirname, './src/utils'),
+      },
+      {
+        find: '@util-types',
+        replacement: resolve(__dirname, './src/utils/types'),
+      },
     ],
   },
 });


### PR DESCRIPTION
size 와 shape 을 결정할 수 있는 Image 컴포넌트를 구현했습니다.

## 🤠 개요

- #12 
- 프로필 이미지나 포인트 이미지 등으로 활용할 수 있는 이미지 컴포넌트를 구현했습니다. 

## 💫 설명

- Image Props 설명 

  - src : 이미지 URL 이나 경로

  - alt : 이미지 설명

  - size : small, medium, large 중 택 1

  - shape : circle, rounded 중 택 1

- 로컬에서 스토리북 실행이 안되서 확인을 못했어요 ( 대신 확인해주시면 감사합니다 )

- 기존에는 React-icon 도 표시할 수 있는 컴포넌트로 만들려고 했지만, 논의 끝에 해당 기능은 Button 컴포넌트에서 텍스트와 함께 구현하는 것으로 결정되었습니다. 

## 📷 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/46566891/220117278-afb3a33e-0f07-4ab3-b491-0c7aa09c9c42.png)
![image](https://user-images.githubusercontent.com/46566891/220117295-e2c38606-cce5-415d-bdd2-71d9565a73ae.png)
![image](https://user-images.githubusercontent.com/46566891/220117310-83ba92e6-415c-4627-8a22-c38890882548.png)
