### PR TITLE
Feat/utils: pixelToRem 메서드 구현

### DIFF
--- a/src/utils/pixelToRem.ts
+++ b/src/utils/pixelToRem.ts
@@ -1,0 +1,18 @@
+export const pixelToRem = (str: PixelString) => {
+  const tokens = str.split(/(\d+px)/);
+
+  const converter = (pre: string, cur: string) => {
+    if (/\d+px/.test(cur)) {
+      const value = Number(/\d+/.exec(cur));
+      return pre + `${value / 16}rem`;
+    }
+
+    return pre + cur;
+  };
+
+  return tokens.reduce(converter, '');
+};
+
+type PixelString = `${Pre}${number}px${Post}`;
+type Pre = `${string} ` | '';
+type Post = ` ${string}` | '';

--- a/src/utils/pixelToRem.ts
+++ b/src/utils/pixelToRem.ts
@@ -1,16 +1,32 @@
 export const pixelToRem = (str: PixelString) => {
   const tokens = str.split(/(\d+px)/);
 
-  const converter = (pre: string, cur: string) => {
+  const reducer = (pre: string, cur: string) => {
     if (/\d+px/.test(cur)) {
       const value = Number(/\d+/.exec(cur));
-      return pre + `${value / 16}rem`;
+
+      return pre + `${converter(value)}rem`;
     }
 
     return pre + cur;
   };
 
-  return tokens.reduce(converter, '');
+  return tokens.reduce(reducer, '');
+};
+
+const converter = (value: number) => {
+  const mod = value % 16;
+
+  switch (true) {
+    case mod < 4:
+      return Math.floor(value / 16);
+    case mod >= 4 && mod < 8:
+      return Math.floor(value / 16) + 0.25;
+    case mod >= 12:
+      return Math.ceil(value / 16) - 0.25;
+    default:
+      return Math.ceil(value / 16) - 0.5;
+  }
 };
 
 type PixelString = `${Pre}${number}px${Post}`;


### PR DESCRIPTION
## 🤠 개요

- Closes #25 

## 💫 설명

- `${number}px`이 포함된 문자열을 받아서 해당 값을 rem 단위로 변환합니다.
- 앞 뒤에 추가 속성이 붙을 수 있습니다.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/63814960/220824293-89e37961-a72a-4e76-a248-1bf789f4125c.png">

## 📷 스크린샷

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/63814960/220824142-8b356d15-f3dd-4415-a1a2-f1f842372e96.png">

