### PR TITLE
Refactor/layout: Flexbox 컴포넌트 리팩토링

### DIFF
--- a/src/components/@layout/Flexbox/Flexbox.stories.tsx
+++ b/src/components/@layout/Flexbox/Flexbox.stories.tsx
@@ -31,7 +31,7 @@ const Template: ComponentStory<typeof Flexbox> = (args) => {
 
 export const Row = Template.bind({});
 Row.args = {
-  direction: 'row',
+  flexDirection: 'row',
 };
 
 export const SpaceBetween = Template.bind({});
@@ -42,7 +42,7 @@ SpaceBetween.args = {
 
 export const MultiLine = Template.bind({});
 MultiLine.args = {
-  wrap: 'wrap',
+  flexWrap: 'wrap',
   alignContent: 'center',
   css: css`
     width: 100px;
@@ -53,5 +53,5 @@ MultiLine.args = {
 
 export const Column = Template.bind({});
 Column.args = {
-  direction: 'column',
+  flexDirection: 'column',
 };

--- a/src/components/@layout/Flexbox/index.tsx
+++ b/src/components/@layout/Flexbox/index.tsx
@@ -1,40 +1,33 @@
-import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
 import { FlexContainerProps } from '@util-types/FlexContainerProps';
 
 type FlexboxProps = DefaultPropsWithChildren<HTMLDivElement> &
   FlexContainerProps;
 
-const Flexbox = ({
-  children,
-  css: style,
-  direction = 'row',
-  wrap = 'nowrap',
-  alignContent = 'normal',
-  alignItems = 'center',
-  justifyContent = 'center',
-  gap = '1rem',
-  ...props
-}: FlexboxProps) => {
-  return (
-    <div
-      css={[
-        css`
-          display: flex;
-          flex-direction: ${direction};
-          flex-wrap: ${wrap};
-          align-content: ${alignContent};
-          align-items: ${alignItems};
-          justify-content: ${justifyContent};
-          gap: ${gap};
-        `,
-        style,
-      ]}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-};
+const Flexbox = styled.div<FlexboxProps>(
+  ({
+    css,
+    flexDirection = 'row',
+    flexWrap = 'nowrap',
+    alignContent = 'normal',
+    alignItems = 'center',
+    justifyContent = 'center',
+    gap = '1rem',
+  }) => {
+    return [
+      {
+        display: 'flex',
+        flexDirection,
+        flexWrap,
+        alignContent,
+        alignItems,
+        justifyContent,
+        gap,
+      },
+      css?.toString(),
+    ];
+  },
+);
 
 export default Flexbox;

--- a/src/components/@layout/List/List.stories.tsx
+++ b/src/components/@layout/List/List.stories.tsx
@@ -36,7 +36,7 @@ Basic.args = {
 
 export const MultiLine = Template.bind({});
 MultiLine.args = {
-  wrap: 'wrap',
+  flexWrap: 'wrap',
   alignContent: 'space-around',
   css: [
     commonStyle,

--- a/src/components/@layout/List/List.stories.tsx
+++ b/src/components/@layout/List/List.stories.tsx
@@ -45,3 +45,9 @@ MultiLine.args = {
     `,
   ],
 };
+
+export const Row = Template.bind({});
+Row.args = {
+  flexDirection: 'row',
+  css: commonStyle,
+};

--- a/src/components/@layout/List/index.tsx
+++ b/src/components/@layout/List/index.tsx
@@ -1,39 +1,18 @@
-import { css } from '@emotion/react';
-import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
-import { FlexContainerProps } from '@util-types/FlexContainerProps';
+import Flexbox from '@components-layout/Flexbox';
+import { Interpolation, Theme } from '@emotion/react';
+import { FlexContainerProps } from '@utils/types/FlexContainerProps';
+import { ReactNode } from 'react';
 
-type ListProps = DefaultPropsWithChildren<HTMLUListElement> &
-  FlexContainerProps;
+type ListProps = FlexContainerProps & {
+  children: ReactNode;
+  css?: Interpolation<Theme>;
+};
 
-const List = ({
-  children,
-  css: style,
-  direction = 'column',
-  wrap = 'nowrap',
-  alignContent = 'normal',
-  alignItems = 'center',
-  justifyContent = 'center',
-  gap = '1rem',
-  ...props
-}: ListProps) => {
+const List = ({ flexDirection = 'column', children, ...props }: ListProps) => {
   return (
-    <ul
-      css={[
-        css`
-          display: flex;
-          flex-direction: ${direction};
-          flex-wrap: ${wrap};
-          align-content: ${alignContent};
-          align-items: ${alignItems};
-          justify-content: ${justifyContent};
-          gap: ${gap};
-        `,
-        style,
-      ]}
-      {...props}
-    >
+    <Flexbox as={'ul'} flexDirection={flexDirection} {...props}>
       {children}
-    </ul>
+    </Flexbox>
   );
 };
 

--- a/src/utils/types/FlexContainerProps.ts
+++ b/src/utils/types/FlexContainerProps.ts
@@ -1,8 +1,8 @@
 import { CSSProperties } from 'react';
 
 export interface FlexContainerProps {
-  direction?: CSSProperties['flexDirection'];
-  wrap?: CSSProperties['flexWrap'];
+  flexDirection?: CSSProperties['flexDirection'];
+  flexWrap?: CSSProperties['flexWrap'];
   alignContent?: CSSProperties['alignContent'];
   alignItems?: CSSProperties['alignItems'];
   justifyContent?: CSSProperties['justifyContent'];


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- `Flexbox` 컴포넌트를 div 외 태그도 사용 가능하도록 개선

<br />

## 💫 설명

- Button 구현하다보니 flex 레이아웃이 필요했습니다.
- 기존의 컴포넌트는 태그가 div로 고정되어있어 레이아웃만 필요한 경우 태그를 중첩해서 사용해야 했고,
- 스타일 적용이 복잡해지겠다는 생각이 들었어요.

- 찾아보니 사용 중인 `@emotion/styled`에 [`as-prop`](https://emotion.sh/docs/styled#as-prop) 기능이 있어서 적용했어요.

```ts
const List = ({ flexDirection = 'column', children, ...props }: ListProps) => {
  return (
    <Flexbox as={'ul'} flexDirection={flexDirection} {...props}>
      {children}
    </Flexbox>
  );
};
```
리팩토링 후 `List` 컴포넌트인데 적용되는 스타일은 같고 as 값으로 넘겨준 태그로 렌더링돼요.

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/63814960/220848321-e0c57d3a-8ae5-4492-802c-f8f30423daa1.png">


<br />

- 작업하다가 발견했는데 개발하면서 넘겨주는 속성들이 문서에 포함되더라고요.
  <img width="1021" alt="image" src="https://user-images.githubusercontent.com/63814960/220844859-3986802a-e2c5-4195-8cff-c5de3922dcad.png">
- 스펙에 존재하는 속성명이면 해당 태그의 속성이 아니라도 이렇게 처리되는 듯 해서 이름 바꿨어요.
