### PR TITLE
Feat/table:  Table 컴포넌트 구현

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,0 +1,189 @@
+import Center from '@components/@layout/Center';
+import Container from '@components/@layout/Container';
+import { ComponentMeta } from '@storybook/react';
+import { ReactNode } from 'react';
+
+import {
+  Table,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableHeadData,
+  TableBodyData,
+} from '.';
+
+export default {
+  title: 'Table',
+  component: Table,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Table>;
+
+const heads = [['column1', 'column2', 'column3']];
+const bodys = [
+  ['data1', 'data2', 'data3'],
+  ['data4', 'data5', 'data6'],
+];
+
+const wrapConatiner = (children: ReactNode) => {
+  return (
+    <Center>
+      <Container css={{ width: 500 }}>{children}</Container>
+    </Center>
+  );
+};
+
+export const Origin = () =>
+  wrapConatiner(
+    <Table>
+      <TableHead>
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData key={text}>{text}</TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );
+
+export const OnlyOutline = () =>
+  wrapConatiner(
+    <Table outline>
+      <TableHead>
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData key={text}>{text}</TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );
+
+export const HeadBackgroundColor = () =>
+  wrapConatiner(
+    <Table outline>
+      <TableHead backgroundColor="primary100" textColor="white">
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData key={text}>{text}</TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );
+
+export const Rounded = () =>
+  wrapConatiner(
+    <Table outline rounded>
+      <TableHead backgroundColor="primary100" textColor="white">
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData key={text}>{text}</TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );
+
+export const Highlight1 = () =>
+  wrapConatiner(
+    <Table outline rounded>
+      <TableHead backgroundColor="primary100" textColor="white">
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData
+                key={text}
+                textColor={text === 'data5' ? 'primary100' : undefined}
+              >
+                {text}
+              </TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );
+
+export const Highlight2 = () =>
+  wrapConatiner(
+    <Table outline rounded>
+      <TableHead backgroundColor="primary100" textColor="white">
+        {heads.map((head, index) => (
+          <TableRow key={`head_${index}`}>
+            {head.map((text) => (
+              <TableHeadData key={text}>{text}</TableHeadData>
+            ))}
+          </TableRow>
+        ))}
+      </TableHead>
+      <TableBody>
+        {bodys.map((body, index) => (
+          <TableRow key={`body_${index}`}>
+            {body.map((text) => (
+              <TableBodyData
+                key={text}
+                backgroundColor={text === 'data5' ? 'gray100' : undefined}
+              >
+                {text}
+              </TableBodyData>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>,
+  );

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -1,0 +1,72 @@
+import { COLOR } from '@constants/color';
+import { TYPOGRAPHY } from '@constants/typography';
+import { CSSProperties } from '@emotion/serialize';
+import styled from '@emotion/styled';
+
+type Color = keyof typeof COLOR;
+
+/**
+ * @name tableCommonStyle: 기본 스타일
+ */
+const tableCommontyle = styled.table<{
+  textColor?: Color;
+  backgroundColor?: Color;
+}>(({ textColor, backgroundColor }) => {
+  return {
+    color: textColor ? COLOR[textColor] : 'inherit',
+    backgroundColor: backgroundColor ? COLOR[backgroundColor] : 'inherit',
+    fontSize: TYPOGRAPHY.desc.size,
+    borderCollapse: 'collapse',
+  };
+});
+
+/**
+ * @name tableDataStyle: th, td 스타일을 디테일하게 적용
+ */
+const tableDataStyle = styled(tableCommontyle.withComponent('td'))<{
+  textAlign?: CSSProperties['textAlign'];
+  fontWeight?: CSSProperties['fontWeight'];
+}>(({ textAlign = 'center', fontWeight = 400 }) => {
+  return {
+    borderCollapse: 'collapse',
+    textAlign,
+    fontWeight,
+  };
+});
+
+/**
+ * @name Table
+ * @prop {outline}: true일 경우 table의 테두리 표시
+ * @prop {rounded}: true일 경우 borderRadius 6px로 설정
+ */
+export const Table = styled(tableCommontyle.withComponent('table'))<{
+  outline?: boolean;
+  rounded?: boolean;
+}>(({ outline = false, rounded = false }) => {
+  return {
+    width: '100%',
+    outline: outline ? `1px solid ${COLOR.gray200}` : 'none',
+    outlineOffset: -1,
+    borderRadius: rounded ? 6 : 0,
+
+    overflow: 'hidden',
+
+    'th, td': {
+      padding: 10,
+      border: outline ? `1px solid ${COLOR.gray200}` : 'none',
+    },
+  };
+});
+
+export const TableHead = styled(tableCommontyle.withComponent('thead'))();
+export const TableBody = styled(tableCommontyle.withComponent('tbody'))();
+export const TableRow = styled(tableCommontyle.withComponent('tr'))();
+
+export const TableHeadData = styled(tableDataStyle.withComponent('th'))(
+  ({ fontWeight = 'bold' }) => {
+    return {
+      fontWeight,
+    };
+  },
+);
+export const TableBodyData = styled(tableDataStyle.withComponent('td'))();

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -8,7 +8,7 @@ type Color = keyof typeof COLOR;
 /**
  * @name tableCommonStyle: 기본 스타일
  */
-const tableCommontyle = styled.table<{
+const tableCommonStyle = styled.table<{
   textColor?: Color;
   backgroundColor?: Color;
 }>(({ textColor, backgroundColor }) => {
@@ -23,7 +23,7 @@ const tableCommontyle = styled.table<{
 /**
  * @name tableDataStyle: th, td 스타일을 디테일하게 적용
  */
-const tableDataStyle = styled(tableCommontyle.withComponent('td'))<{
+const tableDataStyle = styled(tableCommonStyle.withComponent('td'))<{
   textAlign?: CSSProperties['textAlign'];
   fontWeight?: CSSProperties['fontWeight'];
 }>(({ textAlign = 'center', fontWeight = 400 }) => {
@@ -39,7 +39,7 @@ const tableDataStyle = styled(tableCommontyle.withComponent('td'))<{
  * @prop {outline}: true일 경우 table의 테두리 표시
  * @prop {rounded}: true일 경우 borderRadius 6px로 설정
  */
-export const Table = styled(tableCommontyle.withComponent('table'))<{
+export const Table = styled(tableCommonStyle.withComponent('table'))<{
   outline?: boolean;
   rounded?: boolean;
 }>(({ outline = false, rounded = false }) => {
@@ -58,9 +58,9 @@ export const Table = styled(tableCommontyle.withComponent('table'))<{
   };
 });
 
-export const TableHead = styled(tableCommontyle.withComponent('thead'))();
-export const TableBody = styled(tableCommontyle.withComponent('tbody'))();
-export const TableRow = styled(tableCommontyle.withComponent('tr'))();
+export const TableHead = styled(tableCommonStyle.withComponent('thead'))();
+export const TableBody = styled(tableCommonStyle.withComponent('tbody'))();
+export const TableRow = styled(tableCommonStyle.withComponent('tr'))();
 
 export const TableHeadData = styled(tableDataStyle.withComponent('th'))(
   ({ fontWeight = 'bold' }) => {


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes: #28 

## 💫 설명

<!--

- 현재 Pr 설명

-->

- 모든 컴포넌트에 `textColor`, `backgroundColor` props를 전달할 수 있어요.
  - `Table`에는 추가로 `outline`, `rounded`를 전달합니다.
  - `TableHeadData`, `TableBodyData`에는 추가로 `textAlign`, `fontWeight`를 전달합니다.

- `Table` 컴포넌트가 따로 컴포넌트 안에 로직이 필요한거 같지 않아서 (아직은) 그냥 styled 컴포넌트로만 만들어줬어요.

- `color`이름의 props를 사용하니까 html 태그로 바로 들어가버리는 이슈를 저도 당했어요.
  - 그래서 `color` -> `textColor`로 이름을 변경했습니다. 

- `Container`안에서 `Table`을 사용하지 않을까?라고 생각해서 width를 일단 `100%`으로 했어요. 

⚠️ 아, th에 bold 되게 해놨는데 왜 storybook에선 안보이죠?
  - App에선 잘 보여요
    <img width="592" alt="스크린샷 2023-02-24 오후 8 04 34" src="https://user-images.githubusercontent.com/65100540/221171298-692783a7-2b9f-4575-9688-74e1b9246bcb.png">


## 📷 스크린샷
### Origin
<img width="762" alt="스크린샷 2023-02-24 오후 8 31 50" src="https://user-images.githubusercontent.com/65100540/221170180-21a9d8c6-8660-4505-867b-f0cd8b517f2b.png">

### Only Outline
<img width="765" alt="스크린샷 2023-02-24 오후 8 31 58" src="https://user-images.githubusercontent.com/65100540/221170128-65e42ed5-3812-4847-8b2b-69b3a8efaeb3.png">

### Head BackgroundColor
<img width="763" alt="스크린샷 2023-02-24 오후 8 32 05" src="https://user-images.githubusercontent.com/65100540/221170148-c9eafa95-0c5f-449a-9343-f387a6a41717.png">

### Rounded
<img width="762" alt="스크린샷 2023-02-24 오후 8 32 14" src="https://user-images.githubusercontent.com/65100540/221170202-057de38c-e357-4350-a1f4-f37689c0a4de.png">

### Highlight1
<img width="761" alt="스크린샷 2023-02-24 오후 8 32 25" src="https://user-images.githubusercontent.com/65100540/221170217-7a8fd493-c44d-4750-84bd-86e5511117cd.png">

### Highlight2
<img width="758" alt="스크린샷 2023-02-24 오후 8 32 31" src="https://user-images.githubusercontent.com/65100540/221170230-38962577-8d5e-442c-8fec-04c01122b47c.png">
