### PR TITLE
Feat/dropdown: Dropdown 컴포넌트 구현

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -34,7 +34,8 @@ const DUMMY_TOGGLE = () => {
 
 const DUMMY_CUSTOM_ITEM = css`
   font-weight: 700;
-  background-color: red;
+  background-color: aqua;
+  padding: 0.5rem;
 `;
 
 const Template: ComponentStory<typeof Dropdown> = (args) => (

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -20,7 +20,13 @@ export default {
 
 const DUMMY_TOGGLE = () => {
   return (
-    <div>
+    <div
+      style={{
+        border: `1px solid #dedede`,
+        borderRadius: '5px',
+        padding: '.5rem',
+      }}
+    >
       드롭다운토글은커스텀엘레먼트로자유롭게서식을적용할수있습니다테스트를위해아주긴토글을만들었어요
     </div>
   );

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -40,18 +40,23 @@ const DUMMY_CUSTOM_ITEM = css`
 
 const Template: ComponentStory<typeof Dropdown> = (args) => (
   <Dropdown {...args} toggleElement={<DUMMY_TOGGLE />}>
-    <DropdownItem title="첫 번째 아이템" icon={MdAccessibility} />
+    <DropdownItem title="첫 번째 아이템" leftIcon={MdAccessibility} />
     <DropdownItem title="두 번째 아이템" description="저는 설명이 있는데용" />
     <DropdownItem
       title="세 번째 아이템"
       description="저는 설명과 아이콘도 있어용"
-      icon={MdAccessibility}
+      leftIcon={MdAccessibility}
     />
     <DropdownItem
       title="세 번째 아이템(무료 alert 포함)"
       onClick={() => {
         alert('무료로 제공해드리는 alert입니다');
       }}
+    />
+    <DropdownItem
+      title="네 번째 아이템"
+      description="저는 오른쪽에 아이콘이 있어용"
+      rightIcon={MdAccessibility}
     />
     <DropdownCustomItem css={DUMMY_CUSTOM_ITEM}>
       저는 커스텀 아이템 이에용

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { MdAccessibility } from 'react-icons/md';
 
-import { Dropdown, DropdownItem } from '.';
+import { Dropdown, DropdownCustomItem, DropdownItem } from '.';
 
 export default {
   title: 'Dropdown',
@@ -19,8 +19,17 @@ export default {
 } as ComponentMeta<typeof Dropdown>;
 
 const DUMMY_TOGGLE = () => {
-  return <div>Click to expand Dropdown Mesnu!</div>;
+  return (
+    <div>
+      드롭다운토글은커스텀엘레먼트로자유롭게서식을적용할수있습니다테스트를위해아주긴토글을만들었어요
+    </div>
+  );
 };
+
+const DUMMY_CUSTOM_ITEM = css`
+  font-weight: 700;
+  background-color: red;
+`;
 
 const Template: ComponentStory<typeof Dropdown> = (args) => (
   <Dropdown {...args} toggleElement={<DUMMY_TOGGLE />}>
@@ -37,6 +46,9 @@ const Template: ComponentStory<typeof Dropdown> = (args) => (
         alert('무료로 제공해드리는 alert입니다');
       }}
     />
+    <DropdownCustomItem css={DUMMY_CUSTOM_ITEM}>
+      저는 커스텀 아이템 이에용
+    </DropdownCustomItem>
   </Dropdown>
 );
 
@@ -54,10 +66,3 @@ export const Center = Template.bind({});
 Center.args = {
   align: 'center',
 };
-
-// export const Dropdown2 = Template.bind({});
-// Dropdown2.args = {
-//   children: (
-
-//   ),
-// };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { MdAccessibility } from 'react-icons/md';
+
+import { Dropdown, DropdownItem } from '.';
+
+export default {
+  title: 'Dropdown',
+  component: Dropdown,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    align: {
+      options: ['left', 'right', 'center'],
+      control: { type: 'radio' },
+    },
+  },
+} as ComponentMeta<typeof Dropdown>;
+
+const DUMMY_TOGGLE = () => {
+  return <div>Click to expand Dropdown Mesnu!</div>;
+};
+
+const Template: ComponentStory<typeof Dropdown> = (args) => (
+  <Dropdown {...args} toggleElement={<DUMMY_TOGGLE />}>
+    <DropdownItem title="첫 번째 아이템" icon={MdAccessibility} />
+    <DropdownItem title="두 번째 아이템" description="저는 설명이 있는데용" />
+    <DropdownItem
+      title="세 번째 아이템"
+      description="저는 설명과 아이콘도 있어용"
+      icon={MdAccessibility}
+    />
+    <DropdownItem
+      title="세 번째 아이템(무료 alert 포함)"
+      onClick={() => {
+        alert('무료로 제공해드리는 alert입니다');
+      }}
+    />
+  </Dropdown>
+);
+
+export const Left = Template.bind({});
+Left.args = {
+  align: 'left',
+};
+
+export const Right = Template.bind({});
+Right.args = {
+  align: 'right',
+};
+
+export const Center = Template.bind({});
+Center.args = {
+  align: 'center',
+};
+
+// export const Dropdown2 = Template.bind({});
+// Dropdown2.args = {
+//   children: (
+
+//   ),
+// };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,0 +1,145 @@
+import Flexbox from '@components/@layout/Flexbox';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { DefaultProps } from '@utils/types/DefaultProps';
+import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
+import React, { ReactNode, useRef } from 'react';
+import { IconType } from 'react-icons/lib';
+
+type DropdownAlign = 'left' | 'right' | 'center';
+
+interface DropdownProps extends DefaultPropsWithChildren<HTMLDivElement> {
+  toggleElement: ReactNode;
+  align?: DropdownAlign;
+}
+
+const Dropdown = ({
+  children,
+  toggleElement,
+  align = 'left',
+}: DropdownProps) => {
+  const detailsRef = useRef<HTMLDetailsElement | null>(null);
+
+  const closeDropdown = (e: React.MouseEvent) => {
+    const { target } = e;
+    if (!target || !detailsRef.current) return;
+    detailsRef.current.open = false;
+  };
+
+  return (
+    <DropdownWrapper ref={detailsRef}>
+      <summary>{toggleElement}</summary>
+      <DropdownList onClick={closeDropdown} align={align}>
+        {children}
+      </DropdownList>
+    </DropdownWrapper>
+  );
+};
+
+interface ItemProps extends DefaultProps<HTMLLIElement> {
+  title?: string;
+  icon?: IconType;
+  description?: string;
+  onClick?: React.MouseEventHandler;
+}
+
+const DropdownItem = ({
+  title = '',
+  icon: Icon,
+  description = '',
+  onClick: clickEventHandler,
+}: ItemProps) => {
+  return (
+    <DropdownListItem onClick={clickEventHandler}>
+      {Icon && (
+        <Flexbox alignItems="flex-start">
+          <Icon size={'1.2rem'} />
+        </Flexbox>
+      )}
+      <Flexbox
+        direction="column"
+        gap=".3rem"
+        css={css`
+          flex: 1;
+          text-align: left;
+        `}
+      >
+        <ItemTitle>{title}</ItemTitle>
+        <ItemDescription>{description}</ItemDescription>
+      </Flexbox>
+    </DropdownListItem>
+  );
+};
+
+export { Dropdown, DropdownItem };
+
+const DropdownWrapper = styled.details`
+  width: fit-content;
+
+  & > summary {
+    border: 1px solid ${({ theme }) => theme.color.gray200};
+    border-radius: 5px;
+    cursor: pointer;
+    &::marker {
+      content: '';
+    }
+    padding: 0.5rem;
+  }
+
+  &[open] > summary::before {
+    background-color: transparent;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 998;
+    display: block;
+    content: ' ';
+    cursor: default;
+  }
+`;
+
+interface ListProps {
+  align: DropdownAlign;
+}
+
+const DropdownList = styled.ul<ListProps>`
+  float: ${({ align }) => (align === 'right' ? 'right' : 'left')};
+  ${({ align }) =>
+    align === 'center' && 'left: 50%; transform: translateX(-50%);'}
+  z-index: 999;
+  position: relative;
+  width: fit-content;
+  box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.25);
+
+  & > li:not(:first-of-type) {
+    border-top: 1px solid #ccc;
+  }
+`;
+
+const DropdownListItem = styled.li`
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  background-color: white;
+  padding: 0.5rem 0.6rem;
+  gap: 0.2rem;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
+`;
+
+const ItemTitle = styled.div`
+  font-size: 1.2rem;
+  font-weight: 700;
+  width: 100%;
+`;
+
+const ItemDescription = styled.div`
+  font-size: 0.8rem;
+  font-weight: 400;
+  width: 100%;
+`;

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -82,6 +82,7 @@ export { Dropdown, DropdownItem, DropdownCustomItem };
 
 const DropdownWrapper = styled.details`
   width: fit-content;
+  position: relative;
 
   & > summary {
     cursor: pointer;
@@ -109,11 +110,11 @@ interface ListProps {
 }
 
 const DropdownList = styled.ul<ListProps>`
-  float: ${({ align }) => (align === 'right' ? 'right' : 'left')};
+  ${({ align }) => (align === 'right' ? 'right' : 'left')}: 0;
+  position: absolute;
   ${({ align }) =>
     align === 'center' && 'left: 50%; transform: translateX(-50%);'}
   z-index: 999;
-  position: relative;
   width: fit-content;
   box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.25);
   border-radius: 0.2rem;

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -59,19 +59,38 @@ const DropdownItem = ({
       <Flexbox
         direction="column"
         gap=".3rem"
+        alignItems="center"
         css={css`
           flex: 1;
           text-align: left;
         `}
       >
-        <ItemTitle>{title}</ItemTitle>
-        <ItemDescription>{description}</ItemDescription>
+        {title && <ItemTitle>{title}</ItemTitle>}
+        {description && <ItemDescription>{description}</ItemDescription>}
       </Flexbox>
     </DropdownListItem>
   );
 };
 
-export { Dropdown, DropdownItem };
+const DropdownCustomItem = ({
+  children,
+  ...props
+}: DefaultPropsWithChildren<HTMLLIElement>) => {
+  return (
+    <li
+      css={[
+        css`
+          cursor: pointer;
+        `,
+      ]}
+      {...props}
+    >
+      {children}
+    </li>
+  );
+};
+
+export { Dropdown, DropdownItem, DropdownCustomItem };
 
 const DropdownWrapper = styled.details`
   width: fit-content;
@@ -125,7 +144,7 @@ const DropdownListItem = styled.li`
   justify-content: space-between;
   background-color: white;
   padding: 0.5rem 0.6rem;
-  gap: 0.2rem;
+  gap: 1rem;
 
   &:hover {
     filter: brightness(0.95);

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -116,9 +116,18 @@ const DropdownList = styled.ul<ListProps>`
   position: relative;
   width: fit-content;
   box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.25);
+  border-radius: 0.2rem;
 
   & > li:not(:first-of-type) {
     border-top: 1px solid #ccc;
+  }
+
+  & > li:first-of-type {
+    border-radius: 0.2rem 0.2rem 0 0;
+  }
+
+  & > li:last-of-type {
+    border-radius: 0 0 0.2rem 0.2rem;
   }
 `;
 

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -38,22 +38,24 @@ const Dropdown = ({
 
 interface DropdownItemProps extends DefaultProps<HTMLLIElement> {
   title?: string;
-  icon?: IconType;
+  leftIcon?: IconType;
+  rightIcon?: IconType;
   description?: string;
   onClick?: MouseEventHandler;
 }
 
 const DropdownItem = ({
   title = '',
-  icon: Icon,
+  leftIcon: LeftIcon,
+  rightIcon: RightIcon,
   description = '',
   onClick: clickEventHandler,
 }: DropdownItemProps) => {
   return (
     <DropdownListItem onClick={clickEventHandler}>
-      {Icon && (
-        <Flexbox alignItems="flex-start">
-          <Icon size={'1.2rem'} />
+      {LeftIcon && (
+        <Flexbox alignItems="center">
+          <LeftIcon size={'1.2rem'} />
         </Flexbox>
       )}
       <Flexbox
@@ -68,6 +70,11 @@ const DropdownItem = ({
         {title && <ItemTitle>{title}</ItemTitle>}
         {description && <ItemDescription>{description}</ItemDescription>}
       </Flexbox>
+      {RightIcon && (
+        <Flexbox alignItems="center">
+          <RightIcon size={'1.2rem'} />
+        </Flexbox>
+      )}
     </DropdownListItem>
   );
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -84,13 +84,10 @@ const DropdownWrapper = styled.details`
   width: fit-content;
 
   & > summary {
-    border: 1px solid ${({ theme }) => theme.color.gray200};
-    border-radius: 5px;
     cursor: pointer;
     &::marker {
       content: '';
     }
-    padding: 0.5rem;
   }
 
   &[open] > summary::before {

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { DefaultProps } from '@utils/types/DefaultProps';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
-import React, { ReactNode, useRef } from 'react';
+import React, { MouseEvent, MouseEventHandler, ReactNode, useRef } from 'react';
 import { IconType } from 'react-icons/lib';
 
 type DropdownAlign = 'left' | 'right' | 'center';
@@ -20,7 +20,7 @@ const Dropdown = ({
 }: DropdownProps) => {
   const detailsRef = useRef<HTMLDetailsElement | null>(null);
 
-  const closeDropdown = (e: React.MouseEvent) => {
+  const closeDropdown = (e: MouseEvent) => {
     const { target } = e;
     if (!target || !detailsRef.current) return;
     detailsRef.current.open = false;
@@ -40,7 +40,7 @@ interface DropdownItemProps extends DefaultProps<HTMLLIElement> {
   title?: string;
   icon?: IconType;
   description?: string;
-  onClick?: React.MouseEventHandler;
+  onClick?: MouseEventHandler;
 }
 
 const DropdownItem = ({

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -36,7 +36,7 @@ const Dropdown = ({
   );
 };
 
-interface ItemProps extends DefaultProps<HTMLLIElement> {
+interface DropdownItemProps extends DefaultProps<HTMLLIElement> {
   title?: string;
   icon?: IconType;
   description?: string;
@@ -48,7 +48,7 @@ const DropdownItem = ({
   icon: Icon,
   description = '',
   onClick: clickEventHandler,
-}: ItemProps) => {
+}: DropdownItemProps) => {
   return (
     <DropdownListItem onClick={clickEventHandler}>
       {Icon && (
@@ -72,23 +72,11 @@ const DropdownItem = ({
   );
 };
 
-const DropdownCustomItem = ({
-  children,
-  ...props
-}: DefaultPropsWithChildren<HTMLLIElement>) => {
-  return (
-    <li
-      css={[
-        css`
-          cursor: pointer;
-        `,
-      ]}
-      {...props}
-    >
-      {children}
-    </li>
-  );
-};
+const DropdownCustomItem = styled.li<DefaultProps<HTMLLIElement>>(() => {
+  return {
+    cursor: 'pointer',
+  };
+});
 
 export { Dropdown, DropdownItem, DropdownCustomItem };
 


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- Closes: #23 

## 💫 설명

<!--

- 현재 Pr 설명

-->
- form에서 사용되는 드롭다운 input은 일단 이 PR의 적용 대상이 아니에요.
- 따라서 `select - option` HTML 태그 역시 사용하지 않아요. 이걸 연동시키려면 제가 원하는 사용 형태가 나오지 않아요.
- `Dropdown`, `DropdownItem`, `DropdownCustomItem` 세 개의 컴포넌트를 가지고 있어요.
- `Dropdown`은 다음 두 개의 Props를 입력받아요.
  - `toggleElement` : 드롭다운을 토글할 수 있는 요소(=확장 버튼)를 정의해요.
  - `align`(optional) : 드롭다운이 `toggleElement`의 어디에 정렬될 지를 정의해요. `'left' | 'right' | 'center'`가 있고, 기본값은 `'left'`에요.
- `DropdownItem`은 드롭다운에 포함될 각 선택지에요.
  - 아래 사진과 같이 `title`, `description`, `icon`이 배치되고, `onClick`으로 클릭 이벤트 핸들러를 지정해요.
  - `Typography`를 사용하지 않은 이유는 추가 스타일 지정을 할 수가 없어서 글자가 항상 가운데로만 정렬되기 때문이에요.
  - 모든 props는 optional이에요.
![image](https://user-images.githubusercontent.com/46566891/221400994-4ed27752-84e9-4401-89d8-5a8625606c36.png)  
- `DropdownCustomItem`은 형식이 고정된 `DropdownItem`과 다른 형태의 선택지를 만들기 위해 사용해요.

지원해야 할 옵션이 엄청 많다고 생각했는데 어디까지 구현해야하지? 조절이 잘 안돼서 일단 안정적이라고 생각하는 것만 넣었더니 align만 남았어요. 추후 구현할 수도 있는 옵션은 이런 것들이 있어요:
- `expandDirection : 'top' | 'left' | 'right' | 'down'(default)` : 상, 하, 좌, 우로 드롭다운이 확장되는 방향을 지정하고 싶어요.
- `align` : `expandDirection`이 구현된다면 8방향 모서리를 기준으로 지정이 가능하도록 구현해야 할 것 같아요..
- `divisionLine` : 지금은 항목 별로 자동으로 구분선이 그어져요. 커스텀 가능해야 할 것 같아요.
- `expandOn : 'click'(default) | 'hover'` : 지금은 클릭시에만 확장되고 있어요. hover시에도 확장 가능하도록 하고 싶었는데 지금의 구조로는 만족스럽게 작동하지 않아서 삭제했어요.  
- `borderRadius` : 드롭다운 메뉴의 border-radius 속성을 직접 지정할 수 있어야 할 것 같아요. 지금은 기본으로 `0.2rem`이 들어가 있어요.
- `isModal` : 지금은 드롭다운이 확장되면 페이지의 다른 요소와 상호작용이 불가능한 모달 드롭다운이에요. 이걸 설정으로 제거할 수 있게 해야 할지 고민중이에요. 아마 안 할 가능성이 높아요.

사용자 `DropdownCustomItem`에 사용자 CSS가 적용되지 않아서 알아봤는데 아래 글과 같은 일이 있었어요.  
https://boogako.notion.site/DefaultProps-846e0ad869f5468daf82622f1edb4c25

참고한 레퍼런스는 깃허브의 드롭다운이에요.

## 📷 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/46566891/221400820-f775e4be-c773-4776-b569-66a2b0a21b44.png)  
![image](https://user-images.githubusercontent.com/46566891/221400845-eb1e4c24-2c3c-4d6e-98a6-35d029a9f51e.png)  
