### PR TITLE
Feat/modal: Modal 컴포넌트 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <div id="modal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -17,10 +17,10 @@ const SimpleTemplate: ComponentStory<typeof Modal> = (args) => {
     updateArgs({ isOpen: !isOpen });
   };
   return (
-    <>
+    <div>
       <Button onClick={toggleHandler}>Show Modal</Button>
       <Modal {...args} onClose={toggleHandler} />
-    </>
+    </div>
   );
 };
 
@@ -39,10 +39,10 @@ const WithFooterTemplate: ComponentStory<typeof Modal> = (args) => {
     { key: 'Cancel', handler: toggleHandler },
   ];
   return (
-    <>
+    <div>
       <Button onClick={toggleHandler}>Show Modal</Button>
       <Modal {...args} onClose={toggleHandler} footer={footerButtons} />
-    </>
+    </div>
   );
 };
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -41,7 +41,7 @@ const WithFooterTemplate: ComponentStory<typeof Modal> = (args) => {
   return (
     <div>
       <Button onClick={toggleHandler}>Show Modal</Button>
-      <Modal {...args} onClose={toggleHandler} footer={footerButtons} />
+      <Modal {...args} onClose={toggleHandler} actions={footerButtons} />
     </div>
   );
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import { useArgs } from '@storybook/client-api';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
-import Modal from '.';
+import Modal, { Button } from '.';
 
 export default {
   title: 'Modal',
@@ -16,10 +16,15 @@ const SimpleTemplate: ComponentStory<typeof Modal> = (args) => {
   const toggleHandler = () => {
     updateArgs({ isOpen: !isOpen });
   };
-  return <Modal {...args} onClose={toggleHandler} />;
+  return (
+    <>
+      <Button onClick={toggleHandler}>Show Modal</Button>
+      <Modal {...args} onClose={toggleHandler} />
+    </>
+  );
 };
 
-const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
+const WithFooterTemplate: ComponentStory<typeof Modal> = (args) => {
   const [{ isOpen }, updateArgs] = useArgs();
   const toggleHandler = () => {
     updateArgs({ isOpen: !isOpen });
@@ -35,35 +40,44 @@ const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
   ];
   return (
     <>
-      <div>
-        <div>본문 내용</div>
-        <div>본문 내용</div>
-        <div>본문 내용</div>
-        <div>본문 내용</div>
-        <div>본문 내용</div>
-        <div>본문 내용</div>
-        <button onClick={toggleHandler}>Show Modal</button>
-      </div>
+      <Button onClick={toggleHandler}>Show Modal</Button>
       <Modal {...args} onClose={toggleHandler} footer={footerButtons} />
     </>
   );
 };
 
-export const Simple = SimpleTemplate.bind({});
-Simple.args = {
-  title: 'Title',
-  children: (
+const dummyContent = () => {
+  return (
     <div>
       <p>Content1</p>
       <p>Content2</p>
       <p>Content3</p>
     </div>
-  ),
+  );
 };
 
-export const Alert = WithButtonsTemplate.bind({});
-Alert.args = {
-  title: 'Title',
-  children: <p>Content</p>,
+export const OnlyContent = SimpleTemplate.bind({});
+OnlyContent.args = {
   isOpen: false,
+  children: dummyContent(),
+};
+
+export const WithTitle = SimpleTemplate.bind({});
+WithTitle.args = {
+  title: 'Title',
+  isOpen: false,
+  children: dummyContent(),
+};
+
+export const WithFooter = WithFooterTemplate.bind({});
+WithFooter.args = {
+  isOpen: false,
+  children: dummyContent(),
+};
+
+export const WithTitleAndFooter = WithFooterTemplate.bind({});
+WithTitleAndFooter.args = {
+  title: 'Title',
+  isOpen: false,
+  children: dummyContent(),
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,0 +1,73 @@
+import { action } from '@storybook/addon-actions';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
+
+import Modal from '.';
+
+export default {
+  title: 'Modal',
+  component: Modal,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Modal>;
+
+const SimpleTemplate: ComponentStory<typeof Modal> = (args) => {
+  const [open, setOpen] = useState<boolean>(true);
+  const closeHandler = () => {
+    action('onClose');
+    setOpen(false);
+  };
+  return <Modal {...args} isOpen={open} onClose={closeHandler} />;
+};
+
+const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
+  const [open, setOpen] = useState<boolean>(true);
+  const closeHandler = () => {
+    action('onClose');
+    setOpen(false);
+  };
+  const footerButtons = [
+    {
+      key: 'Confirm',
+      handler: () => {
+        return;
+      },
+    },
+    { key: 'Cancel', handler: closeHandler },
+  ];
+  return (
+    <>
+      {open ? (
+        <Modal
+          {...args}
+          isOpen={open}
+          onClose={closeHandler}
+          footer={footerButtons}
+        />
+      ) : (
+        <button style={{ margin: 'auto' }} onClick={() => setOpen(true)}>
+          Show Modal
+        </button>
+      )}
+    </>
+  );
+};
+
+export const Simple = SimpleTemplate.bind({});
+Simple.args = {
+  title: 'Title',
+  children: (
+    <div>
+      <p>Content1</p>
+      <p>Content2</p>
+      <p>Content3</p>
+    </div>
+  ),
+};
+
+export const Alert = WithButtonsTemplate.bind({});
+Alert.args = {
+  title: 'Title',
+  children: <p>Content</p>,
+};

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -22,7 +22,7 @@ const SimpleTemplate: ComponentStory<typeof Modal> = (args) => {
 };
 
 const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
-  const [open, setOpen] = useState<boolean>(true);
+  const [open, setOpen] = useState<boolean>(false);
   const closeHandler = () => {
     action('onClose');
     setOpen(false);
@@ -38,18 +38,21 @@ const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
   ];
   return (
     <>
-      {open ? (
-        <Modal
-          {...args}
-          isOpen={open}
-          onClose={closeHandler}
-          footer={footerButtons}
-        />
-      ) : (
-        <button style={{ margin: 'auto' }} onClick={() => setOpen(true)}>
-          Show Modal
-        </button>
-      )}
+      <div>
+        <div>본문 내용</div>
+        <div>본문 내용</div>
+        <div>본문 내용</div>
+        <div>본문 내용</div>
+        <div>본문 내용</div>
+        <div>본문 내용</div>
+        <button onClick={() => setOpen(true)}>Show Modal</button>
+      </div>
+      <Modal
+        {...args}
+        isOpen={open}
+        onClose={closeHandler}
+        footer={footerButtons}
+      />
     </>
   );
 };

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,5 @@
-import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/client-api';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { useState } from 'react';
 
 import Modal from '.';
 
@@ -13,19 +12,17 @@ export default {
 } as ComponentMeta<typeof Modal>;
 
 const SimpleTemplate: ComponentStory<typeof Modal> = (args) => {
-  const [open, setOpen] = useState<boolean>(true);
-  const closeHandler = () => {
-    action('onClose');
-    setOpen(false);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const toggleHandler = () => {
+    updateArgs({ isOpen: !isOpen });
   };
-  return <Modal {...args} isOpen={open} onClose={closeHandler} />;
+  return <Modal {...args} onClose={toggleHandler} />;
 };
 
 const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
-  const [open, setOpen] = useState<boolean>(false);
-  const closeHandler = () => {
-    action('onClose');
-    setOpen(false);
+  const [{ isOpen }, updateArgs] = useArgs();
+  const toggleHandler = () => {
+    updateArgs({ isOpen: !isOpen });
   };
   const footerButtons = [
     {
@@ -34,7 +31,7 @@ const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
         return;
       },
     },
-    { key: 'Cancel', handler: closeHandler },
+    { key: 'Cancel', handler: toggleHandler },
   ];
   return (
     <>
@@ -45,14 +42,9 @@ const WithButtonsTemplate: ComponentStory<typeof Modal> = (args) => {
         <div>본문 내용</div>
         <div>본문 내용</div>
         <div>본문 내용</div>
-        <button onClick={() => setOpen(true)}>Show Modal</button>
+        <button onClick={toggleHandler}>Show Modal</button>
       </div>
-      <Modal
-        {...args}
-        isOpen={open}
-        onClose={closeHandler}
-        footer={footerButtons}
-      />
+      <Modal {...args} onClose={toggleHandler} footer={footerButtons} />
     </>
   );
 };
@@ -73,4 +65,5 @@ export const Alert = WithButtonsTemplate.bind({});
 Alert.args = {
   title: 'Title',
   children: <p>Content</p>,
+  isOpen: false,
 };

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,8 +4,6 @@ import { TYPOGRAPHY } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 
-// 후에 버튼 컴포넌트 적용 예정
-
 type Handler = () => void;
 type Buttons = { key: string; handler: Handler }[];
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
@@ -80,7 +78,7 @@ const Content = styled.div`
 
 const Footer = styled.div`
   width: 100%;
-  margin-top: 3rem;
+  margin-top: 2rem;
   justify-content: space-between;
 `;
 
@@ -100,15 +98,22 @@ const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
   },
 );
 
-const Button = styled.button(({ theme }) => {
+/**
+ * 임시 Button style
+ * 후에 구현된 Button 컴포넌트로 바꿀 예정
+ */
+export const Button = styled.button(({ theme }) => {
   const { color: themeColor } = theme;
   const { primary100, white } = themeColor;
   return {
-    width: '5rem',
+    width: 'min-content',
     height: '1.7rem',
+    padding: '0 1.2rem',
     borderRadius: '0.5rem',
     backgroundColor: primary100,
     color: white,
+    whiteSpace: 'nowrap',
+    cursor: 'pointer',
     '@media (hover: hover)': {
       ':hover': {
         filter: 'brightness(0.9)',

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,7 +1,6 @@
 import Center from '@components/@layout/Center';
 import Flexbox from '@components/@layout/Flexbox';
 import Typography from '@components/Typography';
-import { TypographyVariant } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler } from 'react';
@@ -20,11 +19,7 @@ const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {
       <BackGround onClick={onClose}></BackGround>
       <Center>
         <ModalBox>
-          {title && (
-            <Typography variant={TypographyVariant.SUBTITLE1}>
-              {title}
-            </Typography>
-          )}
+          {title && <Typography variant="subtitle1">{title}</Typography>}
           <Content>{children}</Content>
           {actions && (
             <Footer>
@@ -53,20 +48,16 @@ const ModalWrapper = styled.div<Pick<ModalProps, 'isOpen'>>`
   justify-content: center;
 `;
 
-const ModalBox = styled.div(({ theme }) => {
-  const { color: themeColor } = theme;
-  const { white } = themeColor;
-  return {
-    width: '20rem',
-    height: 'min-content',
-    position: 'relative',
-    zIndex: 999,
-    padding: '1rem 0',
-    boxShadow: 'rgb(0 0 0 / 20%) 0px 2px 5px 1px',
-    borderRadius: '1rem',
-    backgroundColor: white,
-  };
-});
+const ModalBox = styled.div`
+  width: 20rem;
+  height: min-content;
+  position: relative;
+  z-index: 999;
+  padding: 1rem 0;
+  box-shadow: rgb(0 0 0 / 20%) 0px 2px 5px 1px;
+  border-radius: 1rem;
+  background-color: ${({ theme }) => theme.color.white};
+`;
 
 const Content = styled.div`
   height: min-content;
@@ -79,45 +70,37 @@ const Footer = styled.div`
   justify-content: space-between;
 `;
 
-const BackGround = styled.div(({ theme }) => {
-  const { color: themeColor } = theme;
-  const { black } = themeColor;
-  return {
-    width: '100%',
-    height: '100%',
-    position: 'fixed',
-    zIndex: 998,
-    display: 'flex',
-    opacity: 0.4,
-    backgroundColor: black,
-  };
-});
+const BackGround = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  z-index: 998;
+  display: flex;
+  opacity: 0.4;
+  background-color: ${({ theme }) => theme.color.black};
+`;
 
 /**
  * 임시 Button style
  * 후에 구현된 Button 컴포넌트로 바꿀 예정
  */
-export const Button = styled.button(({ theme }) => {
-  const { color: themeColor } = theme;
-  const { primary100, white } = themeColor;
-  return {
-    width: 'min-content',
-    height: '1.7rem',
-    padding: '0 1.2rem',
-    borderRadius: '0.5rem',
-    backgroundColor: primary100,
-    color: white,
-    whiteSpace: 'nowrap',
-    cursor: 'pointer',
-    '@media (hover: hover)': {
-      ':hover': {
-        filter: 'brightness(0.9)',
-      },
-    },
-    ':active': {
-      filter: 'brightness(0.7)',
-    },
-  };
-});
+export const Button = styled.button`
+  width: min-content;
+  height: 1.7rem;
+  padding: 0 1.2rem;
+  border-radius: 0.5rem;
+  background-color: ${({ theme }) => theme.color.primary100};
+  color: ${({ theme }) => theme.color.white};
+  white-space: nowrap;
+  cursor: pointer;
+  @media (hover: hover) {
+    &:hover {
+      filter: brightness(0.9);
+    }
+  }
+  &:active {
+    filter: brightness(0.7);
+  }
+`;
 
 export default Modal;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -16,7 +16,7 @@ interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
 const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
   return (
     <ModalWrapper {...{ isOpen }}>
-      <BackGround {...{ isOpen }} onClick={onClose}></BackGround>
+      <BackGround onClick={onClose}></BackGround>
       <Center>
         <ModalBox>
           {title && <Title>{title}</Title>}
@@ -82,21 +82,19 @@ const Footer = styled.div`
   justify-content: space-between;
 `;
 
-const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
-  ({ theme, isOpen }) => {
-    const { color: themeColor } = theme;
-    const { black } = themeColor;
-    return {
-      width: '100%',
-      height: '100%',
-      position: 'fixed',
-      zIndex: 998,
-      display: isOpen ? 'flex' : 'none',
-      opacity: 0.4,
-      backgroundColor: black,
-    };
-  },
-);
+const BackGround = styled.div(({ theme }) => {
+  const { color: themeColor } = theme;
+  const { black } = themeColor;
+  return {
+    width: '100%',
+    height: '100%',
+    position: 'fixed',
+    zIndex: 998,
+    display: 'flex',
+    opacity: 0.4,
+    backgroundColor: black,
+  };
+});
 
 /**
  * 임시 Button style

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -6,12 +6,12 @@ import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler } from 'react';
 
-type Actions = { key: string; handler: MouseEventHandler }[];
+type Actions = { key: string; handler: MouseEventHandler };
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
   title?: string;
   isOpen: boolean;
   onClose: MouseEventHandler;
-  actions?: Actions;
+  actions?: Actions[];
 }
 
 const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {
@@ -29,9 +29,9 @@ const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {
           {actions && (
             <Footer>
               <Flexbox justifyContent="space-evenly">
-                {actions.map((btn) => (
-                  <Button key={btn.key} onClick={btn.handler}>
-                    {btn.key}
+                {actions.map(({ key, handler }) => (
+                  <Button key={key} onClick={handler}>
+                    {key}
                   </Button>
                 ))}
               </Flexbox>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -5,15 +5,15 @@ import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler } from 'react';
 
-type Buttons = { key: string; handler: MouseEventHandler }[];
+type Actions = { key: string; handler: MouseEventHandler }[];
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
   title?: string;
   isOpen: boolean;
   onClose: MouseEventHandler;
-  footer?: Buttons;
+  actions?: Actions;
 }
 
-const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
+const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {
   return (
     <ModalWrapper {...{ isOpen }}>
       <BackGround onClick={onClose}></BackGround>
@@ -21,10 +21,10 @@ const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
         <ModalBox>
           {title && <Title>{title}</Title>}
           <Content>{children}</Content>
-          {footer && (
+          {actions && (
             <Footer>
               <Flexbox justifyContent="space-evenly">
-                {footer.map((btn) => (
+                {actions.map((btn) => (
                   <Button key={btn.key} onClick={btn.handler}>
                     {btn.key}
                   </Button>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -3,13 +3,13 @@ import Flexbox from '@components/@layout/Flexbox';
 import { TYPOGRAPHY } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
+import { MouseEventHandler } from 'react';
 
-type Handler = () => void;
-type Buttons = { key: string; handler: Handler }[];
+type Buttons = { key: string; handler: MouseEventHandler }[];
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
   title?: string;
   isOpen: boolean;
-  onClose: Handler;
+  onClose: MouseEventHandler;
   footer?: Buttons;
 }
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -6,12 +6,12 @@ import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler } from 'react';
 
-type Actions = { key: string; handler: MouseEventHandler };
+type Action = { key: string; handler: MouseEventHandler };
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
   title?: string;
   isOpen: boolean;
   onClose: MouseEventHandler;
-  actions?: Actions[];
+  actions?: Action[];
 }
 
 const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,4 +1,6 @@
 import Center from '@components/@layout/Center';
+import Flexbox from '@components/@layout/Flexbox';
+import { TYPOGRAPHY } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 
@@ -17,16 +19,19 @@ const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
       <BackGround {...{ isOpen }} onClick={onClose}></BackGround>
       <Center>
         <ModalBox>
-          <div>{title}</div>
-          {children}
-          <div>
-            {footer &&
-              footer.map((btn) => (
-                <button key={btn.key} onClick={btn.handler}>
-                  {btn.key}
-                </button>
-              ))}
-          </div>
+          {title && <Title>{title}</Title>}
+          <Content>{children}</Content>
+          {footer && (
+            <Footer>
+              <Flexbox justifyContent="space-evenly">
+                {footer.map((btn) => (
+                  <button key={btn.key} onClick={btn.handler}>
+                    {btn.key}
+                  </button>
+                ))}
+              </Flexbox>
+            </Footer>
+          )}
         </ModalBox>
       </Center>
     </ModalWrapper>
@@ -36,6 +41,8 @@ const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
 const ModalWrapper = styled.div<Pick<ModalProps, 'isOpen'>>`
   width: 100%;
   height: 100%;
+  left: 0;
+  top: 0;
   position: fixed;
   display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
   justify-content: center;
@@ -48,13 +55,32 @@ const ModalBox = styled.div(({ theme }) => {
     width: '20rem',
     height: 'min-content',
     position: 'relative',
-    zIndex: 2,
+    zIndex: 999,
     padding: '2rem 0',
     boxShadow: 'rgb(0 0 0 / 20%) 0px 2px 5px 1px',
     borderRadius: '1rem',
     backgroundColor: white,
   };
 });
+
+const Title = styled.div`
+  height: min-content;
+  margin-bottom: 1rem;
+  font-size: ${TYPOGRAPHY.subtitle1.size};
+  font-weight: ${TYPOGRAPHY.subtitle1.weight};
+`;
+
+const Content = styled.div`
+  height: min-content;
+  font-size: ${TYPOGRAPHY.body.size};
+  font-weight: ${TYPOGRAPHY.body.weight};
+`;
+
+const Footer = styled.div`
+  width: 100%;
+  margin-top: 3rem;
+  justify-content: space-between;
+`;
 
 const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
   ({ theme, isOpen }) => {
@@ -64,9 +90,9 @@ const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
       width: '100%',
       height: '100%',
       position: 'fixed',
-      zIndex: 1,
+      zIndex: 998,
       display: isOpen ? 'flex' : 'none',
-      opacity: 0.3,
+      opacity: 0.4,
       backgroundColor: black,
     };
   },

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,6 +1,7 @@
 import Center from '@components/@layout/Center';
 import Flexbox from '@components/@layout/Flexbox';
-import { TYPOGRAPHY } from '@constants/typography';
+import Typography from '@components/Typography';
+import { TypographyVariant } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler } from 'react';
@@ -19,7 +20,11 @@ const Modal = ({ title, children, isOpen, onClose, actions }: ModalProps) => {
       <BackGround onClick={onClose}></BackGround>
       <Center>
         <ModalBox>
-          {title && <Title>{title}</Title>}
+          {title && (
+            <Typography variant={TypographyVariant.SUBTITLE1}>
+              {title}
+            </Typography>
+          )}
           <Content>{children}</Content>
           {actions && (
             <Footer>
@@ -56,24 +61,16 @@ const ModalBox = styled.div(({ theme }) => {
     height: 'min-content',
     position: 'relative',
     zIndex: 999,
-    padding: '2rem 0',
+    padding: '1rem 0',
     boxShadow: 'rgb(0 0 0 / 20%) 0px 2px 5px 1px',
     borderRadius: '1rem',
     backgroundColor: white,
   };
 });
 
-const Title = styled.div`
-  height: min-content;
-  margin-bottom: 1rem;
-  font-size: ${TYPOGRAPHY.subtitle1.size};
-  font-weight: ${TYPOGRAPHY.subtitle1.weight};
-`;
-
 const Content = styled.div`
   height: min-content;
-  font-size: ${TYPOGRAPHY.body.size};
-  font-weight: ${TYPOGRAPHY.body.weight};
+  margin: 1rem 0;
 `;
 
 const Footer = styled.div`

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -4,6 +4,8 @@ import { TYPOGRAPHY } from '@constants/typography';
 import styled from '@emotion/styled';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 
+// 후에 버튼 컴포넌트 적용 예정
+
 type Handler = () => void;
 type Buttons = { key: string; handler: Handler }[];
 interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
@@ -25,9 +27,9 @@ const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
             <Footer>
               <Flexbox justifyContent="space-evenly">
                 {footer.map((btn) => (
-                  <button key={btn.key} onClick={btn.handler}>
+                  <Button key={btn.key} onClick={btn.handler}>
                     {btn.key}
-                  </button>
+                  </Button>
                 ))}
               </Flexbox>
             </Footer>
@@ -97,5 +99,25 @@ const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
     };
   },
 );
+
+const Button = styled.button(({ theme }) => {
+  const { color: themeColor } = theme;
+  const { primary100, white } = themeColor;
+  return {
+    width: '5rem',
+    height: '1.7rem',
+    borderRadius: '0.5rem',
+    backgroundColor: primary100,
+    color: white,
+    '@media (hover: hover)': {
+      ':hover': {
+        filter: 'brightness(0.9)',
+      },
+    },
+    ':active': {
+      filter: 'brightness(0.7)',
+    },
+  };
+});
 
 export default Modal;

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,75 @@
+import Center from '@components/@layout/Center';
+import styled from '@emotion/styled';
+import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
+
+type Handler = () => void;
+type Buttons = { key: string; handler: Handler }[];
+interface ModalProps extends DefaultPropsWithChildren<HTMLDivElement> {
+  title?: string;
+  isOpen: boolean;
+  onClose: Handler;
+  footer?: Buttons;
+}
+
+const Modal = ({ title, children, isOpen, onClose, footer }: ModalProps) => {
+  return (
+    <ModalWrapper {...{ isOpen }}>
+      <BackGround {...{ isOpen }} onClick={onClose}></BackGround>
+      <Center>
+        <ModalBox>
+          <div>{title}</div>
+          {children}
+          <div>
+            {footer &&
+              footer.map((btn) => (
+                <button key={btn.key} onClick={btn.handler}>
+                  {btn.key}
+                </button>
+              ))}
+          </div>
+        </ModalBox>
+      </Center>
+    </ModalWrapper>
+  );
+};
+
+const ModalWrapper = styled.div<Pick<ModalProps, 'isOpen'>>`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
+  justify-content: center;
+`;
+
+const ModalBox = styled.div(({ theme }) => {
+  const { color: themeColor } = theme;
+  const { white } = themeColor;
+  return {
+    width: '20rem',
+    height: 'min-content',
+    position: 'relative',
+    zIndex: 2,
+    padding: '2rem 0',
+    boxShadow: 'rgb(0 0 0 / 20%) 0px 2px 5px 1px',
+    borderRadius: '1rem',
+    backgroundColor: white,
+  };
+});
+
+const BackGround = styled.div<Pick<ModalProps, 'isOpen'>>(
+  ({ theme, isOpen }) => {
+    const { color: themeColor } = theme;
+    const { black } = themeColor;
+    return {
+      width: '100%',
+      height: '100%',
+      position: 'fixed',
+      zIndex: 1,
+      display: isOpen ? 'flex' : 'none',
+      opacity: 0.3,
+      backgroundColor: black,
+    };
+  },
+);
+
+export default Modal;


### PR DESCRIPTION
## 🤠 개요

#30 Modal 컴포넌트 구현

## 💫 설명
### Props
- title: optional props. 모달 내용을 대표하는 제목을 string 타입으로 받습니다.
- isOpen: 모달이 열리고 닫히는 상태. boolean 타입으로 받습니다.
- onClose: 모달을 닫는 handler. () => void 타입의 함수로 받습니다.
- footer: optional props. 모달 하단에 넣을 버튼 목록. 버튼 이름 key와 해당 버튼의 onClick handler가 담긴 객체를 배열로 받습니다. 
ex) { key: "확인", handler: () => {....} }[]

### children
- 모달의 content 내용으로 들어가게 됩니다.

## 📷 스크린샷
### Content만 있는 경우
<img width="940" alt="스크린샷 2023-02-26 오후 11 39 06" src="https://user-images.githubusercontent.com/81913106/221417288-974d7fa0-e332-4781-ac9c-8434e34b2d51.png">

### TItle & Content
<img width="944" alt="스크린샷 2023-02-26 오후 11 39 14" src="https://user-images.githubusercontent.com/81913106/221417285-83eef916-7aa8-40ff-b112-589477f26285.png">

### Content & Footer
<img width="937" alt="스크린샷 2023-02-26 오후 11 39 21" src="https://user-images.githubusercontent.com/81913106/221417283-44e50ad3-76e8-4a5a-b42d-46b54e9c4235.png">

### Title & Content & Footer
<img width="934" alt="스크린샷 2023-02-26 오후 11 39 28" src="https://user-images.githubusercontent.com/81913106/221417282-3fb75ab1-82c4-4ad1-b7f9-605ca2aeb8fd.png">

### 동작
![modal](https://user-images.githubusercontent.com/81913106/221417512-80b50b73-5c50-4943-907b-923b643c5cee.gif)
