### PR TITLE
Fix/dropdown: Flexbox 수정사항 반영

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -59,7 +59,7 @@ const DropdownItem = ({
         </Flexbox>
       )}
       <Flexbox
-        direction="column"
+        flexDirection="column"
         gap=".3rem"
         alignItems="center"
         css={css`

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { DefaultProps } from '@utils/types/DefaultProps';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
-import React, { MouseEvent, MouseEventHandler, ReactNode, useRef } from 'react';
+import { MouseEvent, MouseEventHandler, ReactNode, useRef } from 'react';
 import { IconType } from 'react-icons/lib';
 
 type DropdownAlign = 'left' | 'right' | 'center';


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
브랜치를 파서 Dropdown을 구현하는 사이에 Flexbox의 props 이름이 변경되어 오류가 나는 문제를 수정했어요.  
그리고 그 김에 사용하지 않는 import도 제거했어요.
아래 이슈에 아주 약간 더 자세한 설명이 있어요.
- #38

## 💫 설명

- Flexbox props `direction` -> `flexDirection` 변경
- unused import 제거

## 📷 스크린샷 (Optional)
😱