### PR TITLE
Build/ci: 기본 CI action 추가

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,25 @@
+name: Build Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+      - name: Building app
+        run: |
+          npm i -g yarn
+          yarn
+          yarn build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,11 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
           cache: 'yarn'
           cache-dependency-path: yarn.lock
+
       - name: Building app
         run: |
           npm i -g yarn

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -5,7 +5,7 @@ import {
   IMAGE_SHAPE,
 } from '@constants/image';
 import styled from '@emotion/styled';
-import { DefaultProps } from '@src/utils/types/DefaultProps';
+import { DefaultProps } from '@utils/types/DefaultProps';
 
 type ImageSizeProps = `${ImageSizeVariant}`;
 type ImageShapeProps = `${ImageShapeVariant}`;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
아래 이슈에 의해 기본적으로 `yarn build`를 수행하는 GitHub action을 구현했어요.
- #38

## 💫 설명

<!--

- 현재 Pr 설명

-->

링크된 이슈 #38 에 있는 브랜치룰을 적용하기 위해 기본적인 CI 액션이 필요했어요.  
그리고 기존에 있던 `Image` 컴포넌트의 오류 때문에 모두를 거절하는 슬픈 일을 막기 위해 `Image` 컴포넌트 수정을 끼워넣었어요.

## 📷 스크린샷 (Optional)
![image](https://user-images.githubusercontent.com/46566891/221913693-0e82ddba-4efe-4369-85f3-4b4b851de0dc.png)  
저 거절당했어요~ ✌️✌️