### PR TITLE
Fix/defaultprops: DefaultProps에서 css 프로퍼티 제거

### DIFF
--- a/src/components/@layout/Container/Container.stories.tsx
+++ b/src/components/@layout/Container/Container.stories.tsx
@@ -15,12 +15,13 @@ const Template: ComponentStory<typeof Container> = (args) => (
   <Container {...args} />
 );
 
-export const Basic = Template.bind({});
-Basic.args = {
+export const Basic = Template.bind({
   css: css`
     width: 300px;
     height: 300px;
   `,
+});
+Basic.args = {
   children: (
     <Container
       css={css`
@@ -32,12 +33,13 @@ Basic.args = {
   ),
 };
 
-export const Scrollable = Template.bind({});
-Scrollable.args = {
-  overflowY: 'scroll',
+export const Scrollable = Template.bind({
   css: css`
     height: 100px;
   `,
+});
+Scrollable.args = {
+  overflowY: 'scroll',
   children: (
     <div style={{ height: '300px' }}>Container보다 세로로 더 긴 컨텐츠</div>
   ),

--- a/src/components/@layout/Container/Container.stories.tsx
+++ b/src/components/@layout/Container/Container.stories.tsx
@@ -11,16 +11,15 @@ export default {
   },
 } as ComponentMeta<typeof Container>;
 
-const Template: ComponentStory<typeof Container> = (args) => (
-  <Container {...args} />
+export const Basic: ComponentStory<typeof Container> = (args) => (
+  <Container
+    {...args}
+    css={css`
+      width: 300px;
+      height: 300px;
+    `}
+  />
 );
-
-export const Basic = Template.bind({
-  css: css`
-    width: 300px;
-    height: 300px;
-  `,
-});
 Basic.args = {
   children: (
     <Container
@@ -33,11 +32,14 @@ Basic.args = {
   ),
 };
 
-export const Scrollable = Template.bind({
-  css: css`
-    height: 100px;
-  `,
-});
+export const Scrollable: ComponentStory<typeof Container> = (args) => (
+  <Container
+    {...args}
+    css={css`
+      height: 100px;
+    `}
+  />
+);
 Scrollable.args = {
   overflowY: 'scroll',
   children: (

--- a/src/components/@layout/Container/index.tsx
+++ b/src/components/@layout/Container/index.tsx
@@ -9,7 +9,6 @@ interface ContainerProps extends DefaultPropsWithChildren<HTMLDivElement> {
 
 const Container = ({
   children,
-  css: style,
   overflowX = 'hidden',
   overflowY = 'hidden',
   ...props
@@ -24,7 +23,6 @@ const Container = ({
           overflow-x: ${overflowX};
           overflow-y: ${overflowY};
         `,
-        style,
       ]}
       {...props}
     >

--- a/src/components/@layout/Flexbox/Flexbox.stories.tsx
+++ b/src/components/@layout/Flexbox/Flexbox.stories.tsx
@@ -40,15 +40,16 @@ SpaceBetween.args = {
   gap: '0rem',
 };
 
-export const MultiLine = Template.bind({});
-MultiLine.args = {
-  flexWrap: 'wrap',
-  alignContent: 'center',
+export const MultiLine = Template.bind({
   css: css`
     width: 100px;
     height: 300px;
     background-color: #dfdfdf;
   `,
+});
+MultiLine.args = {
+  flexWrap: 'wrap',
+  alignContent: 'center',
 };
 
 export const Column = Template.bind({});

--- a/src/components/@layout/Flexbox/Flexbox.stories.tsx
+++ b/src/components/@layout/Flexbox/Flexbox.stories.tsx
@@ -11,6 +11,17 @@ export default {
   },
 } as ComponentMeta<typeof Flexbox>;
 
+const items = (
+  <>
+    <p>1</p>
+    <p>2</p>
+    <p>3</p>
+    <p>4</p>
+    <p>5</p>
+    <p>6</p>
+  </>
+);
+
 const Template: ComponentStory<typeof Flexbox> = (args) => {
   const commonStyle = css`
     width: 300px;
@@ -19,12 +30,7 @@ const Template: ComponentStory<typeof Flexbox> = (args) => {
 
   return (
     <Flexbox css={commonStyle} {...args}>
-      <p>1</p>
-      <p>2</p>
-      <p>3</p>
-      <p>4</p>
-      <p>5</p>
-      <p>6</p>
+      {items}
     </Flexbox>
   );
 };
@@ -40,19 +46,25 @@ SpaceBetween.args = {
   gap: '0rem',
 };
 
-export const MultiLine = Template.bind({
-  css: css`
-    width: 100px;
-    height: 300px;
-    background-color: #dfdfdf;
-  `,
-});
-MultiLine.args = {
-  flexWrap: 'wrap',
-  alignContent: 'center',
-};
-
 export const Column = Template.bind({});
 Column.args = {
   flexDirection: 'column',
+};
+
+export const MultiLine: ComponentStory<typeof Flexbox> = (args) => {
+  const narrowWidthStyle = css`
+    width: 100px;
+    height: 300px;
+    background-color: #dfdfdf;
+  `;
+
+  return (
+    <Flexbox css={narrowWidthStyle} {...args}>
+      {items}
+    </Flexbox>
+  );
+};
+MultiLine.args = {
+  flexWrap: 'wrap',
+  alignContent: 'center',
 };

--- a/src/components/@layout/Flexbox/index.tsx
+++ b/src/components/@layout/Flexbox/index.tsx
@@ -7,7 +7,6 @@ type FlexboxProps = DefaultPropsWithChildren<HTMLDivElement> &
 
 const Flexbox = styled.div<FlexboxProps>(
   ({
-    css,
     flexDirection = 'row',
     flexWrap = 'nowrap',
     alignContent = 'normal',
@@ -25,7 +24,6 @@ const Flexbox = styled.div<FlexboxProps>(
         justifyContent,
         gap,
       },
-      css?.toString(),
     ];
   },
 );

--- a/src/utils/types/DefaultProps.ts
+++ b/src/utils/types/DefaultProps.ts
@@ -1,8 +1,6 @@
-import { Interpolation, Theme } from '@emotion/react';
 import { ClassAttributes, HTMLAttributes, ReactNode } from 'react';
 
 export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
   HTMLAttributes<T> & {
-    css?: Interpolation<Theme>;
     children?: ReactNode;
   };


### PR DESCRIPTION
> 수정내역에 문제가 있어요! approve 하지 마세요.
자세한 내용은 내일(03/06) 회의 때 공유할게요

## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
- emotion.jsx에서 정의된 기본 `css` 프로퍼티와 `DefaultProps`의 `css` 프로퍼티 네이밍이 중복되는 문제가 있었어요.
- 아래 이슈에서 이야기한 결론에 따라 `DefaultProps` 인터페이스에서 `css`를 삭제했어요.
- #43
- 지금 각자 브랜치에서 작업중인 내용이 있다면 이 PR에 맞추어 수정해주세요!

## 💫 설명

<!--

- 현재 Pr 설명

-->
스토리북에서 예제를 좀 더 가시적으로 보여주기 위해 컴포넌트에 css를 삽입한 경우가 있는데, 이제 이를 위해서는 css를 `Template.bind` 함수의 인자로 넣어주어야 해요. 커밋에 함께 변경된 스토리 파일들을 보면 다들 금방 이해하실거에요.  
참고로 `bind` 함수는 함수에 인자를 넣어서 다시 생성하는 `Function`의 메소드에요. 저만 몰랐을 수도 있는데 처음 알았어요.  
https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Function/bind  
  
그런데 그럼 이게 더 좋은 모양새냐? 하면 잘 모르겠어요. 근데 엄청 직관성 떨어지거나 안 좋은 코드는 아닌 듯 해서 이대로 가면 될 것 같아요. 익숙하지 않아서 이상하게 느껴지는걸수도
  
선민님이 물어보셔서 설명하려고 생각해보니 막상 emotion이 어떤 식으로 작동하는지 딱 명료하게 정리는 안되네요. 결국 언젠가는 제대로 공부해야 할 것 같아요...

## 📷 스크린샷 (Optional)
