### PR TITLE
Feat/button: Button 컴포넌트 구현

### DIFF
--- a/src/components/@layout/Flexbox/index.tsx
+++ b/src/components/@layout/Flexbox/index.tsx
@@ -1,31 +1,13 @@
 import styled from '@emotion/styled';
+import { flexboxStyle } from '@styles/flex-box';
 import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
 import { FlexContainerProps } from '@util-types/FlexContainerProps';
 
 type FlexboxProps = DefaultPropsWithChildren<HTMLDivElement> &
   FlexContainerProps;
 
-const Flexbox = styled.div<FlexboxProps>(
-  ({
-    flexDirection = 'row',
-    flexWrap = 'nowrap',
-    alignContent = 'normal',
-    alignItems = 'center',
-    justifyContent = 'center',
-    gap = '1rem',
-  }) => {
-    return [
-      {
-        display: 'flex',
-        flexDirection,
-        flexWrap,
-        alignContent,
-        alignItems,
-        justifyContent,
-        gap,
-      },
-    ];
-  },
-);
+const Flexbox = styled.div<FlexboxProps>((props) => {
+  return flexboxStyle(props);
+});
 
 export default Flexbox;

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -19,6 +19,10 @@ Basic.args = {
   text: '상장하기',
 };
 
+export const Disabled: ComponentStory<typeof Button> = () => (
+  <Button icon={MdCelebration} text={'상장하기'} disabled />
+);
+
 export const Link = Template.bind({});
 Link.args = {
   icon: MdCelebration,
@@ -58,6 +62,10 @@ Light.args = {
   text: '상장하기',
   variant: 'light',
 };
+
+export const LightDisabled: ComponentStory<typeof Button> = () => (
+  <Button icon={MdCelebration} text={'상장하기'} variant="light" disabled />
+);
 
 export const Square = Template.bind({});
 Square.args = {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -19,6 +19,13 @@ Basic.args = {
   text: '상장하기',
 };
 
+export const Link = Template.bind({});
+Link.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+  href: 'http://localhost:6006/?path=/story/button--link',
+};
+
 export const IconRight = Template.bind({});
 IconRight.args = {
   icon: MdCelebration,

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -49,25 +49,25 @@ export const Light = Template.bind({});
 Light.args = {
   icon: MdCelebration,
   text: '상장하기',
-  style: 'light',
+  variant: 'light',
 };
 
 export const Square = Template.bind({});
 Square.args = {
   icon: MdCelebration,
   text: '상장하기',
-  style: 'square',
+  variant: 'square',
 };
 
 export const SquareLight = Template.bind({});
 SquareLight.args = {
   icon: MdCelebration,
   text: '상장하기',
-  style: 'square light',
+  variant: 'square light',
 };
 
 export const SquareIconOnly = Template.bind({});
 SquareIconOnly.args = {
   icon: MdCelebration,
-  style: 'square',
+  variant: 'square',
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,0 +1,60 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { MdCelebration } from 'react-icons/md';
+
+import Button from '.';
+
+export default {
+  title: 'Button',
+  component: Button,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Button>;
+
+const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+
+export const Basic = Template.bind({});
+Basic.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+};
+
+export const IconRight = Template.bind({});
+IconRight.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+  iconPosition: 'right',
+  iconTranslateY: '-2px',
+};
+
+export const IconInUrl = Template.bind({});
+IconInUrl.args = {
+  icon: 'https://user-images.githubusercontent.com/63814960/220829587-f305856c-b7bc-4dd0-a199-40735c9da5dc.png',
+  iconSize: '500px',
+  text: '상장하기',
+  iconTranslateY: '-1px',
+};
+
+export const IconOnly = Template.bind({});
+IconOnly.args = {
+  icon: MdCelebration,
+};
+
+export const TextOnly = Template.bind({});
+TextOnly.args = {
+  text: '상장하기',
+};
+
+export const Light = Template.bind({});
+Light.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+  style: 'light',
+};
+
+export const Square = Template.bind({});
+Square.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+  style: 'square',
+};

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -58,3 +58,16 @@ Square.args = {
   text: '상장하기',
   style: 'square',
 };
+
+export const SquareLight = Template.bind({});
+SquareLight.args = {
+  icon: MdCelebration,
+  text: '상장하기',
+  style: 'square light',
+};
+
+export const SquareIconOnly = Template.bind({});
+SquareIconOnly.args = {
+  icon: MdCelebration,
+  style: 'square',
+};

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -75,7 +75,7 @@ const Button = ({
     }
   `;
 
-  const comonProps: Record<string, unknown> = {
+  const commonProps: Record<string, unknown> = {
     css: [flexboxStyle({ gap: '0.125rem' }), buttonStyle],
     ...props,
   };
@@ -102,13 +102,13 @@ const Button = ({
 
   if (href) {
     return (
-      <a href={href} {...comonProps}>
+      <a href={href} {...commonProps}>
         {children}
       </a>
     );
   }
 
-  return <button {...comonProps}>{children}</button>;
+  return <button {...commonProps}>{children}</button>;
 };
 
 const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -6,12 +6,12 @@ import { pixelToRem } from '@utils/pixelToRem';
 import { DefaultProps } from '@utils/types/DefaultProps';
 import { CSSProperties } from 'react';
 
+type ButtonShapeVariant = 'round' | 'square';
+type ButtonThemeVariant = 'light';
 type ButtonVariant =
-  | 'round'
-  | 'square'
-  | 'light'
-  | 'round light'
-  | 'square light';
+  | ButtonShapeVariant
+  | ButtonThemeVariant
+  | `${ButtonShapeVariant} ${ButtonThemeVariant}`;
 
 interface ButtonProps extends DefaultProps<HTMLButtonElement> {
   variant?: ButtonVariant;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -77,7 +77,7 @@ const Button = ({
 
 const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {
   if (isSquare) {
-    return isIconOnly ? '10%' : pixelToRem('16px');
+    return isIconOnly ? '30%' : pixelToRem('16px');
   }
   return isIconOnly ? '50%' : pixelToRem('36px');
 };

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -44,7 +44,7 @@ const Button = ({
 
   const buttonStyle = css`
     width: fit-content;
-    padding: '0.75rem';
+    padding: 0.75rem;
     border-radius: ${getBorderRadius(isSquare, isIconOnly)};
     color: ${isLight ? primary200 : white};
     background-color: ${isLight ? white : primary200};
@@ -58,9 +58,12 @@ const Button = ({
 
     &:hover {
       cursor: pointer;
-      color: ${isLight ? primary400 : white};
       background-color: ${isLight ? white : primary400};
       ${isLight ? `border: 0.125rem solid ${primary400};` : ''}
+
+      & > * {
+        color: ${isLight ? primary400 : white};
+      }
 
       & > svg {
         fill: ${isLight ? primary400 : white};
@@ -93,7 +96,11 @@ const Button = ({
           color={isLight ? primary200 : white}
         />
       )}
-      {text && <Typography variant="body">{text}</Typography>}
+      {text && (
+        <Typography variant="body" color={isLight ? primary200 : white}>
+          {text}
+        </Typography>
+      )}
       {icon && iconPosition === 'right' && (
         <Icon
           source={icon}

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -24,7 +24,7 @@ const Button = ({
   ...props
 }: ButtonProps) => {
   const { color: themeColor } = useTheme();
-  const { white, primary200, primary400 } = themeColor;
+  const { white, primary200, primary400, gray200 } = themeColor;
 
   const isLight = style.includes('light');
   const isSquare = style.includes('square');
@@ -43,7 +43,7 @@ const Button = ({
       transform: translateY(${pixelToRem(`${iconTranslateY}`)});
     }
 
-    :hover {
+    &:hover {
       cursor: pointer;
       color: ${isLight ? primary400 : white};
       background-color: ${isLight ? white : primary400};
@@ -51,6 +51,16 @@ const Button = ({
 
       & > svg {
         fill: ${isLight ? primary400 : white};
+      }
+    }
+
+    &:disabled {
+      color: ${isLight ? gray200 : white};
+      background-color: ${isLight ? white : gray200};
+      ${isLight ? `border: 0.125rem solid ${gray200};` : ''}
+
+      & > svg {
+        fill: ${isLight ? gray200 : white};
       }
     }
   `;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -52,6 +52,7 @@ const Button = ({
       & > svg {
         fill: ${isLight ? primary400 : white};
       }
+    }
   `;
 
   return (

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -47,6 +47,7 @@ const Button = ({
     color: ${isLight ? primary200 : white};
     background-color: ${isLight ? white : primary200};
     ${isLight ? `border: 0.125rem solid ${primary200};` : ''}
+    text-decoration: none;
 
     & > svg,
     & > img {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -5,8 +5,15 @@ import { css, useTheme } from '@emotion/react';
 import { pixelToRem } from '@utils/pixelToRem';
 import { CSSProperties } from 'react';
 
+type ButtonVariant =
+  | 'round'
+  | 'square'
+  | 'light'
+  | 'round light'
+  | 'square light';
+
 interface ButtonProps {
-  style?: 'round' | 'square' | 'light' | 'round light' | 'square light';
+  variant?: ButtonVariant;
   text?: string;
   icon?: IconSource;
   iconSize?: CSSProperties['width'];
@@ -15,7 +22,7 @@ interface ButtonProps {
 }
 
 const Button = ({
-  style = 'round',
+  variant = 'round',
   text,
   icon,
   iconSize = '1.5rem',
@@ -26,8 +33,8 @@ const Button = ({
   const { color: themeColor } = useTheme();
   const { white, primary200, primary400, gray200 } = themeColor;
 
-  const isLight = style.includes('light');
-  const isSquare = style.includes('square');
+  const isLight = variant.includes('light');
+  const isSquare = variant.includes('square');
   const isIconOnly = !!icon && !text;
 
   const buttonCss = css`

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,8 +1,9 @@
 import Icon, { IconSource } from '@components/Icon';
 import Typography from '@components/Typography';
-import Flexbox from '@components-layout/Flexbox';
 import { css, useTheme } from '@emotion/react';
+import { flexboxStyle } from '@styles/flex-box';
 import { pixelToRem } from '@utils/pixelToRem';
+import { DefaultProps } from '@utils/types/DefaultProps';
 import { CSSProperties } from 'react';
 
 type ButtonVariant =
@@ -12,13 +13,14 @@ type ButtonVariant =
   | 'round light'
   | 'square light';
 
-interface ButtonProps {
+interface ButtonProps extends DefaultProps<HTMLButtonElement> {
   variant?: ButtonVariant;
   text?: string;
   icon?: IconSource;
   iconSize?: CSSProperties['width'];
   iconPosition?: 'left' | 'right';
   iconTranslateY?: CSSProperties['translate'];
+  href?: string;
 }
 
 const Button = ({
@@ -28,6 +30,7 @@ const Button = ({
   iconSize = '1.5rem',
   iconPosition = 'left',
   iconTranslateY = 0,
+  href,
   ...props
 }: ButtonProps) => {
   const { color: themeColor } = useTheme();
@@ -37,7 +40,7 @@ const Button = ({
   const isSquare = variant.includes('square');
   const isIconOnly = !!icon && !text;
 
-  const buttonCss = css`
+  const buttonStyle = css`
     width: fit-content;
     padding: ${pixelToRem('12px')};
     border-radius: ${getBorderRadius(isSquare, isIconOnly)};
@@ -72,8 +75,13 @@ const Button = ({
     }
   `;
 
-  return (
-    <Flexbox as="button" gap={'0.125rem'} css={buttonCss} {...props}>
+  const comonProps: Record<string, unknown> = {
+    css: [flexboxStyle({ gap: '0.125rem' }), buttonStyle],
+    ...props,
+  };
+
+  const children = (
+    <>
       {icon && iconPosition === 'left' && (
         <Icon
           source={icon}
@@ -89,8 +97,18 @@ const Button = ({
           color={isLight ? primary200 : white}
         />
       )}
-    </Flexbox>
+    </>
   );
+
+  if (href) {
+    return (
+      <a href={href} {...comonProps}>
+        {children}
+      </a>
+    );
+  }
+
+  return <button {...comonProps}>{children}</button>;
 };
 
 const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -21,6 +21,7 @@ interface ButtonProps extends DefaultProps<HTMLButtonElement> {
   iconPosition?: 'left' | 'right';
   iconTranslateY?: CSSProperties['translate'];
   href?: string;
+  disabled?: boolean;
 }
 
 const Button = ({
@@ -31,6 +32,7 @@ const Button = ({
   iconPosition = 'left',
   iconTranslateY = 0,
   href,
+  disabled,
   ...props
 }: ButtonProps) => {
   const { color: themeColor } = useTheme();
@@ -65,7 +67,8 @@ const Button = ({
       }
     }
 
-    &:disabled {
+    &:disabled,
+    &.disabled {
       color: ${isLight ? gray200 : white};
       background-color: ${isLight ? white : gray200};
       ${isLight ? `border: 0.125rem solid ${gray200};` : ''}
@@ -103,13 +106,17 @@ const Button = ({
 
   if (href) {
     return (
-      <a href={href} {...commonProps}>
+      <a href={href} {...commonProps} className={disabled ? 'disabled' : ''}>
         {children}
       </a>
     );
   }
 
-  return <button {...commonProps}>{children}</button>;
+  return (
+    <button {...commonProps} disabled={disabled}>
+      {children}
+    </button>
+  );
 };
 
 const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -44,7 +44,7 @@ const Button = ({
 
   const buttonStyle = css`
     width: fit-content;
-    padding: ${pixelToRem('12px')};
+    padding: '0.75rem';
     border-radius: ${getBorderRadius(isSquare, isIconOnly)};
     color: ${isLight ? primary200 : white};
     background-color: ${isLight ? white : primary200};
@@ -120,10 +120,10 @@ const Button = ({
 };
 
 const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {
-  if (isSquare) {
-    return isIconOnly ? '30%' : pixelToRem('16px');
-  }
-  return isIconOnly ? '50%' : pixelToRem('36px');
+  const percentage = isSquare ? '30%' : '50%';
+  const rem = isSquare ? '1rem' : '2.25rem';
+
+  return isIconOnly ? percentage : rem;
 };
 
 export default Button;

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,85 @@
+import Icon, { IconSource } from '@components/Icon';
+import Typography from '@components/Typography';
+import Flexbox from '@components-layout/Flexbox';
+import { css, useTheme } from '@emotion/react';
+import { pixelToRem } from '@utils/pixelToRem';
+import { CSSProperties } from 'react';
+
+interface ButtonProps {
+  style?: 'round' | 'square' | 'light' | 'round light' | 'square light';
+  text?: string;
+  icon?: IconSource;
+  iconSize?: CSSProperties['width'];
+  iconPosition?: 'left' | 'right';
+  iconTranslateY?: CSSProperties['translate'];
+}
+
+const Button = ({
+  style = 'round',
+  text,
+  icon,
+  iconSize = '1.5rem',
+  iconPosition = 'left',
+  iconTranslateY = 0,
+  ...props
+}: ButtonProps) => {
+  const { color: themeColor } = useTheme();
+  const { white, primary200, primary400 } = themeColor;
+
+  const isLight = style.includes('light');
+  const isSquare = style.includes('square');
+  const isIconOnly = !!icon && !text;
+
+  const buttonCss = css`
+    width: fit-content;
+    padding: ${pixelToRem('12px')};
+    border-radius: ${getBorderRadius(isSquare, isIconOnly)};
+    color: ${isLight ? primary200 : white};
+    background-color: ${isLight ? white : primary200};
+    ${isLight ? `border: 0.125rem solid ${primary200};` : ''}
+
+    & > svg,
+    & > img {
+      transform: translateY(${pixelToRem(`${iconTranslateY}`)});
+    }
+
+    :hover {
+      cursor: pointer;
+      color: ${isLight ? primary400 : white};
+      background-color: ${isLight ? white : primary400};
+      ${isLight ? `border: 0.125rem solid ${primary400};` : ''}
+
+      & > svg {
+        fill: ${isLight ? primary400 : white};
+      }
+  `;
+
+  return (
+    <Flexbox as="button" gap={'0.125rem'} css={buttonCss} {...props}>
+      {icon && iconPosition === 'left' && (
+        <Icon
+          source={icon}
+          size={iconSize}
+          color={isLight ? primary200 : white}
+        />
+      )}
+      {text && <Typography variant="body">{text}</Typography>}
+      {icon && iconPosition === 'right' && (
+        <Icon
+          source={icon}
+          size={iconSize}
+          color={isLight ? primary200 : white}
+        />
+      )}
+    </Flexbox>
+  );
+};
+
+const getBorderRadius = (isSquare: boolean, isIconOnly: boolean) => {
+  if (isSquare) {
+    return isIconOnly ? '10%' : pixelToRem('16px');
+  }
+  return isIconOnly ? '50%' : pixelToRem('36px');
+};
+
+export default Button;

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -3,7 +3,6 @@ import { IconType } from '@react-icons/all-files';
 import { pixelToRem } from '@utils/pixelToRem';
 import { CSSProperties } from 'react';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type IconSource = string | IconType;
 
 interface IconProps {

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { IconType } from '@react-icons/all-files';
+import { pixelToRem } from '@utils/pixelToRem';
+import { CSSProperties } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type IconSource = string | IconType;
+
+interface IconProps {
+  source: IconSource;
+  size: CSSProperties['width'];
+  color: CSSProperties['fill'];
+}
+
+const Icon = ({ source: Source, size, color }: IconProps) => {
+  if (typeof Source === 'string') {
+    return (
+      <IconContainer
+        src={Source}
+        width={pixelToRem(`${size}`)}
+        height={pixelToRem(`${size}`)}
+      />
+    );
+  }
+
+  return <Source size={size} color={color} />;
+};
+
+const IconContainer = styled.img`
+  max-width: 100%;
+  max-height: 100%;
+  aspect-ratio: 1 / 1;
+`;
+
+export default Icon;

--- a/src/styles/flex-box.ts
+++ b/src/styles/flex-box.ts
@@ -1,0 +1,29 @@
+import { CSSProperties } from 'react';
+
+interface FlexboxStyleProps {
+  flexDirection?: CSSProperties['flexDirection'];
+  flexWrap?: CSSProperties['flexWrap'];
+  alignContent?: CSSProperties['alignContent'];
+  alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
+  gap?: CSSProperties['gap'];
+}
+
+export const flexboxStyle = ({
+  flexDirection = 'row',
+  flexWrap = 'nowrap',
+  alignContent = 'normal',
+  alignItems = 'center',
+  justifyContent = 'center',
+  gap = '1rem',
+}: FlexboxStyleProps) => {
+  return {
+    display: 'flex',
+    flexDirection,
+    flexWrap,
+    alignContent,
+    alignItems,
+    justifyContent,
+    gap,
+  };
+};

--- a/src/utils/pixelToRem.ts
+++ b/src/utils/pixelToRem.ts
@@ -1,4 +1,6 @@
-export const pixelToRem = (str: PixelString) => {
+export const pixelToRem = (str: string) => {
+  if (!str.includes('px')) return str;
+
   const tokens = str.split(/(\d+px)/);
 
   const reducer = (pre: string, cur: string) => {
@@ -15,20 +17,5 @@ export const pixelToRem = (str: PixelString) => {
 };
 
 const converter = (value: number) => {
-  const mod = value % 16;
-
-  switch (true) {
-    case mod < 4:
-      return Math.floor(value / 16);
-    case mod >= 4 && mod < 8:
-      return Math.floor(value / 16) + 0.25;
-    case mod >= 12:
-      return Math.ceil(value / 16) - 0.25;
-    default:
-      return Math.ceil(value / 16) - 0.5;
-  }
+  return value % 2 ? (value + 1) / 16 : value / 16;
 };
-
-type PixelString = `${Pre}${number}px${Post}`;
-type Pre = `${string} ` | '';
-type Post = ` ${string}` | '';


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #22 
- **드디어 !!!** Button 컴포넌트를 구현했습니다.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/63814960/222961966-fa7d184c-9e83-4553-852e-51771fc53286.png">

## 💫 설명

- 컴포넌트 Props는 아래와 같습니다.
  ```ts
  interface ButtonProps extends DefaultProps<HTMLButtonElement> {
    variant?: ButtonVariant;    // 스타일 종류, default: 'round'

    text?: string;              // 텍스트

    icon?: IconSource;          // 아이콘, 문자열 또는 react-icons의 JSXconstructor
    iconSize?: CSSProperties['width'];
    iconPosition?: 'left' | 'right';
    iconTranslateY?: CSSProperties['translate'];

    href?: string;              // 버튼이 링크로 사용되는 경우를 위한 href
  }

  type ButtonVariant =
    | 'round'
    | 'square'
    | 'light'
    | 'round light'
    | 'square light';
  ```

<br />

- `Icon` 컴포넌트는 우선 현재 작업에서 사용할 수 있도록 만들었습니다. 뭔가 공부할게 좀 있어서 추후 개선하며 stories 추가할 예정입니다.

  - `IconTypography`는 별로 사용성 좋은 컴포넌트가 아닌 것 같아 만들지 않았습니다. 나중에 필요하다고 판단되면 Icon 컴포넌트 활용해서 추가할 수 있습니다.
    <img width="592" alt="image" src="https://user-images.githubusercontent.com/63814960/222953710-70c85f95-9672-45c5-8322-0e850413c55c.png">

## 📷 스크린샷

https://user-images.githubusercontent.com/63814960/222953447-72eb4384-1855-45c5-b753-6a5b591919e4.mov

<br />

### TBD

- 사용할 때 불편함이 있어 pixelToRem 메서드를 살짝 수정했습니다.
  <img width="655" alt="image" src="https://user-images.githubusercontent.com/63814960/222953814-9318d369-e455-4dc0-88e2-41a34eb118ad.png">
  - [ ] 얘 파일명이 컨벤션에 맞지 않아서 수정이 필요한데 여기저기서 많이 사용하고 있을 것 같아서 회의 때 확인하고 수정할게요!

- [x] type 속성을 추가해야하는데 FlexBox 컴포넌트 Props 관련해서 이슈가 있어서 #44 PR 머지 이후에 수정하겠습니다.
  - 83b677b32e633e86f6e1564e3d43dc07ab679b88 에서 flexboxStyle을 분리해서 작업했어요. 나중에 Flexbox 쪽에 반영하기만 하면 됩니다. 혹시 더 좋은 방법이 있으면 알려주세요!
    <img width="763" alt="image" src="https://user-images.githubusercontent.com/63814960/222961679-91e19c81-a40c-4f57-9d44-988582f64954.png">
