### PR TITLE
Refactor/enum-types: enum 기반 타입 string literal로 변경

### DIFF
--- a/src/@types/variant.d.ts
+++ b/src/@types/variant.d.ts
@@ -1,0 +1,12 @@
+declare type TypographyVariant =
+  | 'title1'
+  | 'title2'
+  | 'subtitle1'
+  | 'subtitle2'
+  | 'body'
+  | 'desc';
+
+declare type ImageSizeVariant = 'small' | 'medium' | 'large';
+declare type ImageShapeVariant = 'circle' | 'rounded';
+
+declare type SpinnerSizeVariant = 'small' | 'large';

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,20 +1,12 @@
-import {
-  ImageSizeVariant,
-  ImageShapeVariant,
-  IMAGE_SIZE,
-  IMAGE_SHAPE,
-} from '@constants/image';
+import { IMAGE_SIZE, IMAGE_SHAPE } from '@constants/image';
 import styled from '@emotion/styled';
-import { DefaultProps } from '@src/utils/types/DefaultProps';
-
-type ImageSizeProps = `${ImageSizeVariant}`;
-type ImageShapeProps = `${ImageShapeVariant}`;
+import { DefaultProps } from '@util-types/DefaultProps';
 
 interface ImageProps extends DefaultProps<HTMLImageElement> {
   src: string;
   alt: string;
-  size: ImageSizeProps;
-  shape?: ImageShapeProps;
+  size: ImageSizeVariant;
+  shape?: ImageShapeVariant;
 }
 
 const Image = ({ src, alt, size, shape }: ImageProps) => {

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,8 +1,9 @@
-import { SPINNER_SIZE } from '@constants/spinner';
+import { SPINNER_STYLE } from '@constants/spinner';
+import { Theme } from '@emotion/react';
 import styled from '@emotion/styled';
 
 interface SpinnerProps {
-  size: 'small' | 'large';
+  size: SpinnerSizeVariant;
 }
 
 const Spinner = ({ size = 'small' }: SpinnerProps) => {
@@ -15,18 +16,24 @@ const Spinner = ({ size = 'small' }: SpinnerProps) => {
   );
 };
 
-const SpinnerContainer = styled.div<SpinnerProps>(({ theme, size }) => {
-  const { color: themeColor } = theme;
-  const { white } = themeColor;
-  const { small, large } = SPINNER_SIZE;
-  return {
-    width: size === 'small' ? small.OUTCIRCLE : large.OUTCIRCLE,
-    height: size === 'small' ? small.OUTCIRCLE : large.OUTCIRCLE,
-    display: 'inline-block',
-    overflow: 'hidden',
-    background: white,
-  };
-});
+type SpinnerStyleProps = {
+  theme: Theme;
+} & SpinnerProps;
+
+const SpinnerContainer = styled.div<SpinnerProps>(
+  ({ theme, size }: SpinnerStyleProps) => {
+    const { color: themeColor } = theme;
+    const { white } = themeColor;
+
+    return {
+      width: SPINNER_STYLE[size].OUTCIRCLE,
+      height: SPINNER_STYLE[size].OUTCIRCLE,
+      display: 'inline-block',
+      overflow: 'hidden',
+      background: white,
+    };
+  },
+);
 
 const Spin = styled.div`
   width: 100%;
@@ -45,24 +52,23 @@ const Spin = styled.div`
   }
 `;
 
-const Circle = styled.div<SpinnerProps>(({ theme, size }) => {
-  const { color: themeColor } = theme;
-  const { primary100 } = themeColor;
-  const { small, large } = SPINNER_SIZE;
-  return {
-    position: 'absolute',
-    width: size === 'small' ? small.INNERCIRCLE : large.INNERCIRCLE,
-    height: size === 'small' ? small.INNERCIRCLE : large.INNERCIRCLE,
-    border:
-      size === 'small'
-        ? `${small.STROKEWIDTH} solid ${primary100}`
-        : `${large.STROKEWIDTH} solid ${primary100}`,
-    borderTopColor: 'transparent',
-    borderRadius: '50%',
-    animation: 'spin-animation 1s linear infinite',
-    top: size === 'small' ? small.INNERCIRCLE : large.INNERCIRCLE,
-    left: size === 'small' ? small.INNERCIRCLE : large.INNERCIRCLE,
-  };
-});
+const Circle = styled.div<SpinnerProps>(
+  ({ theme, size }: SpinnerStyleProps) => {
+    const { color: themeColor } = theme;
+    const { primary100 } = themeColor;
+
+    return {
+      position: 'absolute',
+      width: SPINNER_STYLE[size].INNERCIRCLE,
+      height: SPINNER_STYLE[size].INNERCIRCLE,
+      border: `${SPINNER_STYLE[size].STROKEWIDTH} solid ${primary100}`,
+      borderTopColor: 'transparent',
+      borderRadius: '50%',
+      animation: 'spin-animation 1s linear infinite',
+      top: SPINNER_STYLE[size].INNERCIRCLE,
+      left: SPINNER_STYLE[size].INNERCIRCLE,
+    };
+  },
+);
 
 export default Spinner;

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,10 +1,6 @@
-import {
-  TypographyVariant as Variant,
-  TYPOGRAPHY,
-} from '@constants/typography';
+import { TYPOGRAPHY } from '@constants/typography';
 import { css, jsx } from '@emotion/react';
 
-type TypographyVariant = `${Variant}`;
 interface TypographyProps {
   variant: TypographyVariant;
   children: string;
@@ -12,13 +8,13 @@ interface TypographyProps {
 
 const getTypography = (variant: TypographyVariant): string => {
   switch (variant) {
-    case Variant.TITLE1:
+    case 'title1':
       return 'h1';
-    case Variant.TITLE2:
+    case 'title2':
       return 'h2';
-    case Variant.SUBTITLE1:
+    case 'subtitle1':
       return 'h3';
-    case Variant.SUBTITLE2:
+    case 'subtitle2':
       return 'h4';
     default:
       return 'p';

--- a/src/constants/image.ts
+++ b/src/constants/image.ts
@@ -1,21 +1,10 @@
-export enum ImageSizeVariant {
-  SMALL = 'small',
-  MEDIUM = 'medium',
-  LARGE = 'large',
-}
-
-export enum ImageShapeVariant {
-  CIRCLE = 'circle',
-  ROUNDED = 'rounded',
-}
-
 export const IMAGE_SIZE: Record<ImageSizeVariant, string> = {
-  [ImageSizeVariant.SMALL]: '2rem',
-  [ImageSizeVariant.MEDIUM]: '3rem',
-  [ImageSizeVariant.LARGE]: '4rem',
+  small: '2rem',
+  medium: '3rem',
+  large: '4rem',
 } as const;
 
 export const IMAGE_SHAPE: Record<ImageShapeVariant, string> = {
-  [ImageShapeVariant.CIRCLE]: '50%',
-  [ImageShapeVariant.ROUNDED]: '30px',
+  circle: '50%',
+  rounded: '30px',
 };

--- a/src/constants/spinner.ts
+++ b/src/constants/spinner.ts
@@ -1,21 +1,16 @@
-export enum SpinnerSizeVariant {
-  SMALL = 'small',
-  LARGE = 'large',
-}
-
-export interface SpinDesignVariant {
+interface SpinnerStyle {
   OUTCIRCLE: string;
   INNERCIRCLE: string;
   STROKEWIDTH: string;
 }
 
-export const SPINNER_SIZE: Record<SpinnerSizeVariant, SpinDesignVariant> = {
-  [SpinnerSizeVariant.SMALL]: {
+export const SPINNER_STYLE: Record<SpinnerSizeVariant, SpinnerStyle> = {
+  small: {
     OUTCIRCLE: '1.875rem',
     INNERCIRCLE: '0.938rem',
     STROKEWIDTH: '0.125rem',
   },
-  [SpinnerSizeVariant.LARGE]: {
+  large: {
     OUTCIRCLE: '3.125rem',
     INNERCIRCLE: '1.563rem',
     STROKEWIDTH: '0.188rem',

--- a/src/constants/typography.ts
+++ b/src/constants/typography.ts
@@ -1,39 +1,30 @@
-export enum TypographyVariant {
-  TITLE1 = 'title1',
-  TITLE2 = 'title2',
-  SUBTITLE1 = 'subtitle1',
-  SUBTITLE2 = 'subtitle2',
-  BODY = 'body',
-  DESC = 'desc',
-}
-
 interface Font {
   size: string;
   weight: number;
 }
 
 export const TYPOGRAPHY: Record<TypographyVariant, Font> = {
-  [TypographyVariant.TITLE1]: {
+  title1: {
     size: '3rem',
     weight: 900,
   },
-  [TypographyVariant.TITLE2]: {
+  title2: {
     size: '2.25rem',
     weight: 900,
   },
-  [TypographyVariant.SUBTITLE1]: {
+  subtitle1: {
     size: '1.5rem',
     weight: 700,
   },
-  [TypographyVariant.SUBTITLE2]: {
+  subtitle2: {
     size: '1.25rem',
     weight: 700,
   },
-  [TypographyVariant.BODY]: {
+  body: {
     size: '1rem',
     weight: 400,
   },
-  [TypographyVariant.DESC]: {
+  desc: {
     size: '0.75rem',
     weight: 400,
   },

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@components/*": ["./src/components/*"],
       "@components-common/*": ["./src/components/@common/*"],
       "@components-layout/*": ["./src/components/@layout/*"],
+      "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
       "@styles/*": ["./src/styles/*"],
-      "@utils/*": ["./src/utils/*"],
-      "@util-types/*": ["./src/utils/types/*"]
+      "@util-types/*": ["./src/utils/types/*"],
+      "@utils/*": ["./src/utils/*"]
     }
   }
 }


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- 상수로 썼던 enum type들을 string literal로 변경합니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->

- 상수가 아니라는게 왠지 너무 찝찝했는데 사실 리터럴 타입만으로 type-safety 보장된다고 합니다.

- 자동완성 지원하고 불필요한 코드도 줄어들어요.

- 이런 타입들을 선언하는 `@types/variant.d.ts` 파일을 만들었어요.

- `import { DefaultProps } from '@util-types/DefaultProps';` 자동완성 이렇게 만들어주려고 절대경로 순서도 바꾸었어요.

## 📖 참고 자료

https://fettblog.eu/tidy-typescript-avoid-enums/

> a simple string union type does just what you need: Type-safety, auto-complete, predictable behavior.
> 
> 
> You get all the benefits from enums like proper tooling and type-safety without going the extra round and risking to output code that you don’t want. It also becomes clearer what you need to pass, and where to get the value from. No need to manually map back-end strings to an enum just for the sake of it. Simple, clear, **tidy**!
> 

- 이유를 요약하면 별로 권장하지 않는 부작용들이 있고
  - Enums emit code
  - Numeric enums are not type-safe
  - String enums are named types
- string union만으로 이미 type-safe하고 타이디하게 개발할 수 있어서 !!