### PR TITLE
Fix: Typography color default value inherit으로 변경

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -96,11 +96,7 @@ const Button = ({
           color={isLight ? primary200 : white}
         />
       )}
-      {text && (
-        <Typography variant="body" color={isLight ? primary200 : white}>
-          {text}
-        </Typography>
-      )}
+      {text && <Typography variant="body">{text}</Typography>}
       {icon && iconPosition === 'right' && (
         <Icon
           source={icon}

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,3 +1,4 @@
+import { useTheme } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Highlight from './Highlight';
@@ -12,11 +13,16 @@ export default {
   },
 } as ComponentMeta<typeof Typography>;
 
-const Template: ComponentStory<typeof Typography> = (args) => (
-  <Typography {...args}>
-    안녕하세요. 콜드스터디 디자인 시스템입니다. 🧊
-  </Typography>
-);
+const Template: ComponentStory<typeof Typography> = (args) => {
+  const { color } = useTheme();
+  const { black } = color;
+
+  return (
+    <Typography color={black} {...args}>
+      안녕하세요. 콜드스터디 디자인 시스템입니다. 🧊
+    </Typography>
+  );
+};
 
 export const Title1 = Template.bind({});
 Title1.args = {
@@ -54,16 +60,26 @@ Title1WithColor.args = {
   color: 'blue',
 };
 
-export const Title1Highlighted: ComponentStory<typeof Typography> = () => (
-  <Typography variant="title1">
-    안녕하세요. <Highlight>콜드스터디</Highlight> 디자인 시스템입니다. 🧊
-  </Typography>
-);
+export const Title1Highlighted: ComponentStory<typeof Typography> = () => {
+  const { color } = useTheme();
+  const { black } = color;
 
-export const Title1CustomHighlighted: ComponentStory<typeof Typography> =
-  () => (
-    <Typography variant="title1">
-      안녕하세요. <Highlight color="blue">콜드스터디</Highlight> 디자인
-      시스템입니다. 🧊
+  return (
+    <Typography variant="title1" color={black}>
+      안녕하세요. <Highlight>콜드스터디</Highlight> 디자인 시스템입니다. 🧊
     </Typography>
   );
+};
+
+export const Title1CustomHighlighted: ComponentStory<typeof Typography> =
+  () => {
+    const { color } = useTheme();
+    const { black } = color;
+
+    return (
+      <Typography variant="title1" color={black}>
+        안녕하세요. <Highlight color="blue">콜드스터디</Highlight> 디자인
+        시스템입니다. 🧊
+      </Typography>
+    );
+  };

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,5 +1,5 @@
 import { TYPOGRAPHY } from '@constants/typography';
-import { css, jsx, useTheme } from '@emotion/react';
+import { css, jsx } from '@emotion/react';
 import { CSSProperties, ReactNode, ReactPortal } from 'react';
 
 type TextNode = Exclude<
@@ -30,14 +30,13 @@ const getTypography = (variant: TypographyVariant): string => {
 
 const Typography = ({ children, variant = 'body', color }: TypographyProps) => {
   const typography = getTypography(variant);
-  const { color: themeColor } = useTheme();
 
   return jsx(
     typography,
     {
       css: css`
         margin: 0;
-        color: ${color ?? themeColor.black};
+        color: ${color ?? 'inherit'};
         font-size: ${TYPOGRAPHY[variant].size};
         font-weight: ${TYPOGRAPHY[variant].weight};
       `,


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- #51 추가 작업

- 기존 컴포넌트들에서 설정한 color 스타일이 적용되지 않는 이슈가 있어 inherit으로 설정했습니다.

## 💫 설명

- 변경하면서 Button 쪽 color 지정했던 것도 제거했어요.

- 텍스트로 사용할 때 color 스타일은 컨테이너에든, Typography props로든 명시하면서 쓰는게 좋아요!

  - 웹에서는 기본값이 검정색이지만 저희 팔레트는 `#222222` 사용하고 있고,

  - iOS에서는 시스템 설정값이 파란색이라서 스타일링이 달라질 수 있어요 https://developer.apple.com/forums/thread/690529

```tsx
const buttonStyle = css`
  width: fit-content;
  padding: 0.75rem;
  border-radius: ${getBorderRadius(isSquare, isIconOnly)};
  color: ${isLight ? primary200 : white};
```
```tsx
export const Title1Highlighted: ComponentStory<typeof Typography> = () => {
  const { color } = useTheme();
  const { black } = color;

  return (
    <Typography variant="title1" color={black}>
      안녕하세요. <Highlight>콜드스터디</Highlight> 디자인 시스템입니다. 🧊
    </Typography>
  );
};
```

- 반성문: 다음부터는 기존 작업에 부작용 없는지 잘 확인하고 머지할게요 ...😵
