### PR TITLE
Feat/rangeSelector : RangeSelector 컴포넌트 구현 

### DIFF
--- a/src/components/RangeSelector/RangeSelector.stories.tsx
+++ b/src/components/RangeSelector/RangeSelector.stories.tsx
@@ -27,7 +27,7 @@ StartFromZero.args = {
   min: 0,
   max: 100,
   init: 0,
-  size: 200,
+  trackWidth: 200,
 };
 
 export const StartFromHalf = Template.bind({});
@@ -35,7 +35,7 @@ StartFromHalf.args = {
   min: 0,
   max: 100,
   init: 50,
-  size: 200,
+  trackWidth: 200,
 };
 
 export const StartFromEnd = Template.bind({});
@@ -43,7 +43,7 @@ StartFromEnd.args = {
   min: 0,
   max: 100,
   init: 100,
-  size: 200,
+  trackWidth: 200,
 };
 
 export const MinValueVariant = Template.bind({});
@@ -51,7 +51,7 @@ MinValueVariant.args = {
   min: 50,
   max: 100,
   init: 75,
-  size: 200,
+  trackWidth: 200,
 };
 
 export const MaxValueVariant = Template.bind({});
@@ -59,7 +59,7 @@ MaxValueVariant.args = {
   min: 50,
   max: 200,
   init: 100,
-  size: 200,
+  trackWidth: 200,
 };
 
 export const SizeVariant = Template.bind({});
@@ -67,5 +67,5 @@ SizeVariant.args = {
   min: 0,
   max: 100,
   init: 50,
-  size: 500,
+  trackWidth: 500,
 };

--- a/src/components/RangeSelector/RangeSelector.stories.tsx
+++ b/src/components/RangeSelector/RangeSelector.stories.tsx
@@ -1,0 +1,71 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { RangeSelector } from '.';
+
+export default {
+  title: 'RangeSelector',
+  component: RangeSelector,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof RangeSelector>;
+
+const DEFAULT_PROPS = {
+  id: 'default',
+  label: 'Primitive 슬라이더',
+};
+
+const Template: ComponentStory<typeof RangeSelector> = (args) => (
+  <RangeSelector {...args} {...DEFAULT_PROPS}>
+    <RangeSelector.Slider />
+    <RangeSelector.RangeDisplay />
+  </RangeSelector>
+);
+
+export const StartFromZero = Template.bind({});
+StartFromZero.args = {
+  min: 0,
+  max: 100,
+  init: 0,
+  size: 200,
+};
+
+export const StartFromHalf = Template.bind({});
+StartFromHalf.args = {
+  min: 0,
+  max: 100,
+  init: 50,
+  size: 200,
+};
+
+export const StartFromEnd = Template.bind({});
+StartFromEnd.args = {
+  min: 0,
+  max: 100,
+  init: 100,
+  size: 200,
+};
+
+export const MinValueVariant = Template.bind({});
+MinValueVariant.args = {
+  min: 50,
+  max: 100,
+  init: 75,
+  size: 200,
+};
+
+export const MaxValueVariant = Template.bind({});
+MaxValueVariant.args = {
+  min: 50,
+  max: 200,
+  init: 100,
+  size: 200,
+};
+
+export const SizeVariant = Template.bind({});
+SizeVariant.args = {
+  min: 0,
+  max: 100,
+  init: 50,
+  size: 500,
+};

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -1,0 +1,123 @@
+import Flexbox from '@components/@layout/Flexbox';
+import Typography from '@components/Typography';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { createContext, ReactNode, useContext, useRef, useState } from 'react';
+
+const RangeSelectorContext =
+  createContext<
+    | (Omit<RangeSelectorProps, 'init' | 'children'> & {
+        value: number;
+        setValue: React.Dispatch<React.SetStateAction<number>>;
+      })
+    | null
+  >(null);
+
+interface RangeSelectorProps {
+  min: number;
+  max: number;
+  init: number;
+  size: number;
+  children: ReactNode;
+  color?: string;
+}
+
+const RangeSelector = ({
+  min,
+  max,
+  init,
+  size,
+  color,
+  children,
+}: RangeSelectorProps) => {
+  const [value, setValue] = useState<number>(init);
+
+  const providerValue = { value, setValue, min, max, size, color };
+
+  return (
+    <RangeSelectorContext.Provider value={providerValue}>
+      <Flexbox
+        flexDirection="column"
+        css={css`
+          width: ${size}px;
+          padding: 1rem;
+        `}
+      >
+        {children}
+      </Flexbox>
+    </RangeSelectorContext.Provider>
+  );
+};
+
+const RangeDisplay = () => {
+  const context = useContext(RangeSelectorContext);
+
+  if (context === null) return null;
+  return (
+    <Flexbox
+      justifyContent={'space-between'}
+      css={css`
+        position: relative;
+        width: inherit;
+        user-select: none;
+      `}
+    >
+      <Typography variant={'desc'}>{context.min.toString()}</Typography>
+      <Typography variant={'desc'}>{context.max.toString()}</Typography>
+    </Flexbox>
+  );
+};
+
+const Slider = () => {
+  const context = useContext(RangeSelectorContext);
+  const TrackRef = useRef<HTMLDivElement | null>(null);
+  const FilledRef = useRef<HTMLDivElement | null>(null);
+  const ThumbRef = useRef<HTMLDivElement | null>(null);
+
+  if (context === null) return null;
+  return (
+    <Flexbox>
+      <Track ref={TrackRef} size={context.size} />
+      <Filled ref={FilledRef} size={context.size} />
+      <Thumb ref={ThumbRef}>
+        <Flexbox justifyContent={'center'} alignItems={'center'}>
+          <Typography variant={'desc'}>{context.value.toString()}</Typography>
+        </Flexbox>
+      </Thumb>
+    </Flexbox>
+  );
+};
+
+interface TrackProps {
+  size: number;
+}
+
+const Track = styled.div<TrackProps>`
+  width: ${({ size }) => size + 'px'};
+  height: 1px;
+  border: 1px solid lightgray;
+`;
+
+const Filled = styled.div<TrackProps>`
+  position: absolute;
+  left: 1rem;
+  height: 3px;
+  background-color: skyblue;
+  cursor: pointer;
+`;
+
+const Thumb = styled.div`
+  position: absolute;
+  left: 1rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 2rem;
+  background-color: skyblue;
+  user-select: none;
+  cursor: pointer;
+`;
+
+RangeSelector.Slider = Slider;
+RangeSelector.RangeDisplay = RangeDisplay;
+
+export { RangeSelectorContext, RangeSelector };

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -78,6 +78,8 @@ const RangeDisplay = () => {
   );
 };
 
+const fixInt = (float: number) => Number(float.toFixed(0));
+
 const calcRangeValue = (
   size: number,
   max: number,
@@ -88,10 +90,9 @@ const calcRangeValue = (
 ) =>
   max -
   min -
-  +(
-    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) *
-    100
-  ).toFixed(0);
+  fixInt(
+    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) * 100,
+  );
 
 const setSliderPos = (
   size: number,
@@ -145,8 +146,8 @@ const Slider = () => {
       const { left, right } = trackRef.current.getBoundingClientRect();
       const { width: offset } = thumbRef.current.getBoundingClientRect();
 
-      minPosRef.current = left + offset / 2;
-      maxPosRef.current = right - offset / 2;
+      minPosRef.current = fixInt(left) + offset / 2;
+      maxPosRef.current = fixInt(right) - offset / 2;
       offsetRef.current = offset;
 
       const thumbPos = setSliderPos(size, max, min, value, offset);
@@ -224,7 +225,6 @@ const Thumb = styled.div`
   background-color: skyblue;
   user-select: none;
   cursor: pointer;
-  opacity: 50%;
 `;
 
 RangeSelector.Slider = Slider;

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -84,8 +84,8 @@ const calcRangeValue = (
   max: number,
   min: number,
   maxPos: number,
-  currentX: number,
-) => max - min - Math.floor(((maxPos - currentX - 8) / size) * 100);
+  mousePos: number,
+) => max - min - Math.floor(((maxPos - mousePos) / size) * 100);
 
 const setInitialThumbPos = (
   max: number,
@@ -98,30 +98,30 @@ const setInitialThumbPos = (
 const Slider = () => {
   const context = useContext(RangeSelectorContext);
   const [movable, setMovable] = useState<boolean>(false);
-  const minXPosRef = useRef<number>(0);
-  const maxXPosRef = useRef<number>(0);
-  const TrackRef = useRef<HTMLDivElement | null>(null);
-  const FilledRef = useRef<HTMLDivElement | null>(null);
-  const ThumbRef = useRef<HTMLDivElement | null>(null);
+  const minPosRef = useRef<number>(0);
+  const maxPosRef = useRef<number>(0);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const filledRef = useRef<HTMLDivElement | null>(null);
+  const thumbRef = useRef<HTMLDivElement | null>(null);
 
   const thumbWidth = useMemo(() => {
-    return ThumbRef.current
-      ? ThumbRef.current?.getBoundingClientRect().width
+    return thumbRef.current
+      ? thumbRef.current?.getBoundingClientRect().width
       : 0;
-  }, [ThumbRef.current]);
+  }, [thumbRef.current]);
 
   const handleThumbPosition = (
     e: MouseEvent<HTMLDivElement> | globalThis.MouseEvent,
   ) => {
-    if (ThumbRef.current && FilledRef.current && TrackRef.current && context) {
+    if (thumbRef.current && filledRef.current && trackRef.current && context) {
       let clickedPos = e.clientX;
-      if (clickedPos > maxXPosRef.current) {
-        clickedPos = maxXPosRef.current;
-      } else if (clickedPos < minXPosRef.current) {
-        clickedPos = minXPosRef.current;
+      if (clickedPos > maxPosRef.current) {
+        clickedPos = maxPosRef.current;
+      } else if (clickedPos < minPosRef.current) {
+        clickedPos = minPosRef.current;
       }
-      ThumbRef.current.style.left = `${clickedPos - thumbWidth / 2}px`;
-      FilledRef.current.style.width = `${
+      thumbRef.current.style.left = `${clickedPos - thumbWidth / 2}px`;
+      filledRef.current.style.width = `${
         clickedPos - thumbWidth - thumbWidth / 2
       }px`;
       context.setValue(
@@ -129,7 +129,7 @@ const Slider = () => {
           context.size - thumbWidth,
           context.max,
           context.min,
-          maxXPosRef.current + thumbWidth / 2,
+          maxPosRef.current,
           clickedPos,
         ),
       );
@@ -137,15 +137,15 @@ const Slider = () => {
   };
 
   useLayoutEffect(() => {
-    if (TrackRef.current && ThumbRef.current && FilledRef.current && context) {
+    if (trackRef.current && thumbRef.current && filledRef.current && context) {
       const { max, min, value } = context;
-      const { left, right } = TrackRef.current.getBoundingClientRect();
-      const { width } = ThumbRef.current.getBoundingClientRect();
-      minXPosRef.current = left + width / 2;
-      maxXPosRef.current = right - width / 2;
+      const { left, right } = trackRef.current.getBoundingClientRect();
+      const { width } = thumbRef.current.getBoundingClientRect();
+      minPosRef.current = left + width / 2;
+      maxPosRef.current = right - width / 2;
       const initialPos = setInitialThumbPos(max, min, right, left, value);
-      ThumbRef.current.style.left = initialPos + width + 'px';
-      FilledRef.current.style.width = initialPos + 'px';
+      thumbRef.current.style.left = initialPos + width + 'px';
+      filledRef.current.style.width = initialPos + 'px';
     }
   }, []);
 
@@ -162,8 +162,8 @@ const Slider = () => {
         });
 
         if (!movable) return;
-        if (e.clientX > maxXPosRef.current) return;
-        if (e.clientX < minXPosRef.current) return;
+        if (e.clientX > maxPosRef.current) return;
+        if (e.clientX < minPosRef.current) return;
         handleThumbPosition(e);
       },
       { signal },
@@ -173,13 +173,13 @@ const Slider = () => {
   if (context === null) return null;
   return (
     <Flexbox>
-      <Track ref={TrackRef} size={context.size} onClick={handleThumbPosition} />
+      <Track ref={trackRef} size={context.size} onClick={handleThumbPosition} />
       <Filled
-        ref={FilledRef}
+        ref={filledRef}
         size={context.size}
         onClick={handleThumbPosition}
       />
-      <Thumb ref={ThumbRef} onMouseDown={() => setMovable(true)}>
+      <Thumb ref={thumbRef} onMouseDown={() => setMovable(true)}>
         <Flexbox justifyContent={'center'} alignItems={'center'}>
           <Typography variant={'desc'}>{context.value.toString()}</Typography>
         </Flexbox>

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -110,7 +110,7 @@ const setSliderPos = (
   min: number,
   value: number,
   offset?: number,
-) => ((offset ? size - offset : size) / (max - min)) * value;
+) => ((offset ? size - offset : size) / (max - min)) * (value - min);
 
 const Slider = () => {
   const context = useContext(RangeSelectorContext);
@@ -144,11 +144,11 @@ const Slider = () => {
         clickedPos,
         offsetRef.current,
       );
-      const rangePos = setSliderPos(size, max, min, rangeValue);
+      const rangePos = setSliderPos(size, max, min, rangeValue + min);
 
       thumbRef.current.style.left = `${clickedPos - offsetRef.current / 2}px`;
       trackRef.current.style.setProperty('--filled', `${rangePos}px`);
-      setValue(rangeValue);
+      setValue(min + rangeValue);
     }
   };
 

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -17,15 +17,13 @@ import {
   useState,
 } from 'react';
 
-interface RangeSelectorContextInterface {
-  id: string;
-  label: string;
-  min: number;
-  max: number;
-  trackWidth: number;
+type RangeSelectorContextInterface = Omit<
+  RangeSelectorProps,
+  'init' | 'children'
+> & {
   value: number;
   setValue: Dispatch<SetStateAction<number>>;
-}
+};
 
 const RangeSelectorContext =
   createContext<RangeSelectorContextInterface | null>(null);

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -90,7 +90,8 @@ const calcRangeValue = (
   max -
   min -
   fixInt(
-    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) * 100,
+    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) *
+      (max - min),
   );
 
 const setSliderPos = (

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -95,22 +95,19 @@ const calcRangeValue = (
   min: number,
   maxPos: number,
   mousePos: number,
-  offset?: number,
+  offset = 0,
 ) =>
   max -
   min -
-  fixInt(
-    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) *
-      (max - min),
-  );
+  fixInt((Math.round(maxPos - mousePos) / (size - offset)) * (max - min));
 
 const setSliderPos = (
   size: number,
   max: number,
   min: number,
   value: number,
-  offset?: number,
-) => ((offset ? size - offset : size) / (max - min)) * (value - min);
+  offset = 0,
+) => ((size - offset) / (max - min)) * (value - min);
 
 const Slider = () => {
   const context = useContext(RangeSelectorContext);
@@ -178,10 +175,14 @@ const Slider = () => {
       window.addEventListener(
         'mousemove',
         (e) => {
-          window.addEventListener('mouseup', () => {
-            setMovable(false);
-            controller.abort();
-          });
+          window.addEventListener(
+            'mouseup',
+            () => {
+              setMovable(false);
+              controller.abort();
+            },
+            { signal },
+          );
 
           if (!movable) return;
           if (e.clientX > maxPosRef.current) return;

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -25,6 +25,8 @@ const RangeSelectorContext =
   >(null);
 
 interface RangeSelectorProps {
+  id: string;
+  label: string;
   min: number;
   max: number;
   init: number;
@@ -33,6 +35,8 @@ interface RangeSelectorProps {
 }
 
 const RangeSelector = ({
+  id,
+  label,
   min,
   max,
   init,
@@ -41,12 +45,14 @@ const RangeSelector = ({
 }: RangeSelectorProps) => {
   const [value, setValue] = useState<number>(init);
 
-  const providerValue = { value, setValue, min, max, size };
+  const providerValue = { id, label, value, setValue, min, max, size };
 
   return (
     <RangeSelectorContext.Provider value={providerValue}>
       <Flexbox
         flexDirection="column"
+        role={'slider'}
+        aria-label={label}
         css={css`
           width: ${size}px;
           padding: 1rem;
@@ -71,8 +77,12 @@ const RangeDisplay = () => {
         user-select: none;
       `}
     >
-      <Typography variant={'desc'}>{context.min.toString()}</Typography>
-      <Typography variant={'desc'}>{context.max.toString()}</Typography>
+      <Typography variant={'desc'} aria-valuemin={context.min}>
+        {context.min.toString()}
+      </Typography>
+      <Typography variant={'desc'} aria-valuemax={context.max}>
+        {context.max.toString()}
+      </Typography>
     </Flexbox>
   );
 };
@@ -187,19 +197,24 @@ const Slider = () => {
   return (
     <Flexbox>
       <Track
+        id={`${context.id}_track`}
         ref={trackRef}
         size={context.size}
         trackColor={gray100}
         filledColor={primary100}
         onClick={handleThumbPosition}
+        aria-orientation={'horizontal'}
       />
       <Thumb
         ref={thumbRef}
         thumbColor={primary100}
         onMouseDown={() => setMovable(true)}
+        aria-controls={`${context.id}_track`}
       >
         <Flexbox justifyContent={'center'} alignItems={'center'}>
-          <Typography variant={'desc'}>{context.value.toString()}</Typography>
+          <Typography variant={'desc'} aria-valuenow={context.value}>
+            {context.value.toString()}
+          </Typography>
         </Flexbox>
       </Thumb>
     </Flexbox>

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -154,21 +154,23 @@ const Slider = () => {
     const controller = new AbortController();
     const { signal } = controller;
 
-    window.addEventListener(
-      'mousemove',
-      (e) => {
-        window.addEventListener('mouseup', () => {
-          setMovable(false);
-          controller.abort();
-        });
+    if (movable) {
+      window.addEventListener(
+        'mousemove',
+        (e) => {
+          window.addEventListener('mouseup', () => {
+            setMovable(false);
+            controller.abort();
+          });
 
-        if (!movable) return;
-        if (e.clientX > maxPosRef.current) return;
-        if (e.clientX < minPosRef.current) return;
-        handleThumbPosition(e);
-      },
-      { signal },
-    );
+          if (!movable) return;
+          if (e.clientX > maxPosRef.current) return;
+          if (e.clientX < minPosRef.current) return;
+          handleThumbPosition(e);
+        },
+        { signal },
+      );
+    }
   }, [movable]);
 
   if (context === null) return null;

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@components/@common/CdsProvider/theme';
 import Flexbox from '@components/@layout/Flexbox';
 import Typography from '@components/Typography';
 import { css } from '@emotion/react';
@@ -29,7 +30,6 @@ interface RangeSelectorProps {
   init: number;
   size: number;
   children: ReactNode;
-  color?: string;
 }
 
 const RangeSelector = ({
@@ -37,12 +37,11 @@ const RangeSelector = ({
   max,
   init,
   size,
-  color,
   children,
 }: RangeSelectorProps) => {
   const [value, setValue] = useState<number>(init);
 
-  const providerValue = { value, setValue, min, max, size, color };
+  const providerValue = { value, setValue, min, max, size };
 
   return (
     <RangeSelectorContext.Provider value={providerValue}>
@@ -110,6 +109,8 @@ const Slider = () => {
   const offsetRef = useRef<number>(0);
   const trackRef = useRef<HTMLDivElement | null>(null);
   const thumbRef = useRef<HTMLDivElement | null>(null);
+  const { color: themeColor } = theme;
+  const { primary100, gray100 } = themeColor;
 
   const handleThumbPosition = (
     e: MouseEvent<HTMLDivElement> | globalThis.MouseEvent,
@@ -184,8 +185,18 @@ const Slider = () => {
   if (context === null) return null;
   return (
     <Flexbox>
-      <Track ref={trackRef} size={context.size} onClick={handleThumbPosition} />
-      <Thumb ref={thumbRef} onMouseDown={() => setMovable(true)}>
+      <Track
+        ref={trackRef}
+        size={context.size}
+        trackColor={gray100}
+        filledColor={primary100}
+        onClick={handleThumbPosition}
+      />
+      <Thumb
+        ref={thumbRef}
+        thumbColor={primary100}
+        onMouseDown={() => setMovable(true)}
+      >
         <Flexbox justifyContent={'center'} alignItems={'center'}>
           <Typography variant={'desc'}>{context.value.toString()}</Typography>
         </Flexbox>
@@ -196,13 +207,15 @@ const Slider = () => {
 
 interface TrackProps {
   size: number;
+  trackColor: string;
+  filledColor: string;
   onClick: MouseEventHandler<HTMLDivElement>;
 }
 
 const Track = styled.div<TrackProps>`
   width: ${({ size }) => size + 'px'};
   height: 3px;
-  background-color: lightgray;
+  background-color: ${({ trackColor }) => trackColor};
   cursor: pointer;
 
   ::after {
@@ -211,18 +224,22 @@ const Track = styled.div<TrackProps>`
     width: var(--filled);
     height: 3px;
     display: inline-block;
-    background-color: skyblue;
+    background-color: ${({ filledColor }) => filledColor};
     cursor: pointer;
   }
 `;
 
-const Thumb = styled.div`
+interface ThumbProps {
+  thumbColor: string;
+}
+
+const Thumb = styled.div<ThumbProps>`
   position: absolute;
   left: 0;
   width: 1rem;
   height: 1rem;
   border-radius: 2rem;
-  background-color: skyblue;
+  background-color: ${({ thumbColor }) => thumbColor};
   user-select: none;
   cursor: pointer;
 `;

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -7,6 +7,7 @@ import {
   MouseEvent,
   MouseEventHandler,
   ReactNode,
+  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
@@ -85,7 +86,7 @@ const calcRangeValue = (
   min: number,
   maxPos: number,
   mousePos: number,
-) => max - min - Math.floor(((maxPos - mousePos) / size) * 100);
+) => max - min - +((Math.round(maxPos - mousePos) / size) * 100).toFixed(0);
 
 const setSliderPos = (size: number, max: number, min: number, value: number) =>
   (size / (max - min)) * value;
@@ -108,25 +109,27 @@ const Slider = () => {
     e: MouseEvent<HTMLDivElement> | globalThis.MouseEvent,
   ) => {
     if (thumbRef.current && trackRef.current && context) {
+      const { size, max, min, setValue } = context;
       let clickedPos = e.clientX;
+
       if (clickedPos > maxPosRef.current) {
         clickedPos = maxPosRef.current;
       } else if (clickedPos < minPosRef.current) {
         clickedPos = minPosRef.current;
       }
-      const value = calcRangeValue(
-        context.size - thumbWidth,
-        context.max,
-        context.min,
+
+      const rangeValue = calcRangeValue(
+        size - thumbWidth,
+        max,
+        min,
         maxPosRef.current,
         clickedPos,
       );
+      const rangePos = setSliderPos(size, max, min, rangeValue);
+
       thumbRef.current.style.left = `${clickedPos - thumbWidth / 2}px`;
-      trackRef.current.style.setProperty(
-        '--filled',
-        setSliderPos(context.size, context.max, context.min, value) + 'px',
-      );
-      context.setValue(value);
+      trackRef.current.style.setProperty('--filled', rangePos + 'px');
+      setValue(rangeValue);
     }
   };
 
@@ -197,9 +200,9 @@ const Track = styled.div<TrackProps>`
     position: absolute;
     width: var(--filled);
     height: 3px;
+    display: inline-block;
     background-color: skyblue;
     cursor: pointer;
-    display: inline-block;
   }
 `;
 

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -7,11 +7,9 @@ import {
   MouseEvent,
   MouseEventHandler,
   ReactNode,
-  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -96,14 +94,9 @@ const Slider = () => {
   const [movable, setMovable] = useState<boolean>(false);
   const minPosRef = useRef<number>(0);
   const maxPosRef = useRef<number>(0);
+  const offsetRef = useRef<number>(0);
   const trackRef = useRef<HTMLDivElement | null>(null);
   const thumbRef = useRef<HTMLDivElement | null>(null);
-
-  const thumbWidth = useMemo(() => {
-    return thumbRef.current
-      ? thumbRef.current?.getBoundingClientRect().width
-      : 0;
-  }, [thumbRef.current]);
 
   const handleThumbPosition = (
     e: MouseEvent<HTMLDivElement> | globalThis.MouseEvent,
@@ -119,7 +112,7 @@ const Slider = () => {
       }
 
       const rangeValue = calcRangeValue(
-        size - thumbWidth,
+        size - offsetRef.current,
         max,
         min,
         maxPosRef.current,
@@ -127,7 +120,7 @@ const Slider = () => {
       );
       const rangePos = setSliderPos(size, max, min, rangeValue);
 
-      thumbRef.current.style.left = `${clickedPos - thumbWidth / 2}px`;
+      thumbRef.current.style.left = `${clickedPos - offsetRef.current / 2}px`;
       trackRef.current.style.setProperty('--filled', rangePos + 'px');
       setValue(rangeValue);
     }
@@ -141,6 +134,7 @@ const Slider = () => {
 
       minPosRef.current = left + width / 2;
       maxPosRef.current = right - width / 2;
+      offsetRef.current = width;
 
       const thumbPos = setSliderPos(size - width, max, min, value);
       const filledTrackPos = setSliderPos(size, max, min, value);

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -4,7 +4,9 @@ import Typography from '@components/Typography';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import {
+  SetStateAction,
   createContext,
+  Dispatch,
   MouseEvent,
   MouseEventHandler,
   ReactNode,
@@ -15,14 +17,18 @@ import {
   useState,
 } from 'react';
 
+interface RangeSelectorContextInterface {
+  id: string;
+  label: string;
+  min: number;
+  max: number;
+  trackWidth: number;
+  value: number;
+  setValue: Dispatch<SetStateAction<number>>;
+}
+
 const RangeSelectorContext =
-  createContext<
-    | (Omit<RangeSelectorProps, 'init' | 'children'> & {
-        value: number;
-        setValue: React.Dispatch<React.SetStateAction<number>>;
-      })
-    | null
-  >(null);
+  createContext<RangeSelectorContextInterface | null>(null);
 
 interface RangeSelectorProps {
   id: string;

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -84,10 +84,22 @@ const calcRangeValue = (
   min: number,
   maxPos: number,
   mousePos: number,
-) => max - min - +((Math.round(maxPos - mousePos) / size) * 100).toFixed(0);
+  offset?: number,
+) =>
+  max -
+  min -
+  +(
+    (Math.round(maxPos - mousePos) / (offset ? size - offset : size)) *
+    100
+  ).toFixed(0);
 
-const setSliderPos = (size: number, max: number, min: number, value: number) =>
-  (size / (max - min)) * value;
+const setSliderPos = (
+  size: number,
+  max: number,
+  min: number,
+  value: number,
+  offset?: number,
+) => ((offset ? size - offset : size) / (max - min)) * value;
 
 const Slider = () => {
   const context = useContext(RangeSelectorContext);
@@ -112,16 +124,17 @@ const Slider = () => {
       }
 
       const rangeValue = calcRangeValue(
-        size - offsetRef.current,
+        size,
         max,
         min,
         maxPosRef.current,
         clickedPos,
+        offsetRef.current,
       );
       const rangePos = setSliderPos(size, max, min, rangeValue);
 
       thumbRef.current.style.left = `${clickedPos - offsetRef.current / 2}px`;
-      trackRef.current.style.setProperty('--filled', rangePos + 'px');
+      trackRef.current.style.setProperty('--filled', `${rangePos}px`);
       setValue(rangeValue);
     }
   };
@@ -130,17 +143,17 @@ const Slider = () => {
     if (trackRef.current && thumbRef.current && context) {
       const { size, max, min, value } = context;
       const { left, right } = trackRef.current.getBoundingClientRect();
-      const { width } = thumbRef.current.getBoundingClientRect();
+      const { width: offset } = thumbRef.current.getBoundingClientRect();
 
-      minPosRef.current = left + width / 2;
-      maxPosRef.current = right - width / 2;
-      offsetRef.current = width;
+      minPosRef.current = left + offset / 2;
+      maxPosRef.current = right - offset / 2;
+      offsetRef.current = offset;
 
-      const thumbPos = setSliderPos(size - width, max, min, value);
+      const thumbPos = setSliderPos(size, max, min, value, offset);
       const filledTrackPos = setSliderPos(size, max, min, value);
 
-      thumbRef.current.style.left = left + thumbPos + 'px';
-      trackRef.current.style.setProperty('--filled', filledTrackPos + 'px');
+      thumbRef.current.style.left = `${left + thumbPos}px`;
+      trackRef.current.style.setProperty('--filled', `${filledTrackPos}px`);
     }
   }, []);
 

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -104,9 +104,9 @@ const Slider = () => {
   const FilledRef = useRef<HTMLDivElement | null>(null);
   const ThumbRef = useRef<HTMLDivElement | null>(null);
 
-  const thumbHalfWidth = useMemo(() => {
+  const thumbWidth = useMemo(() => {
     return ThumbRef.current
-      ? ThumbRef.current?.getBoundingClientRect().width / 2
+      ? ThumbRef.current?.getBoundingClientRect().width
       : 0;
   }, [ThumbRef.current]);
 
@@ -115,19 +115,21 @@ const Slider = () => {
   ) => {
     if (ThumbRef.current && FilledRef.current && TrackRef.current && context) {
       let clickedPos = e.clientX;
-      if (clickedPos > maxXPosRef.current - 8) {
+      if (clickedPos > maxXPosRef.current) {
         clickedPos = maxXPosRef.current;
-      } else if (clickedPos < minXPosRef.current + 8) {
+      } else if (clickedPos < minXPosRef.current) {
         clickedPos = minXPosRef.current;
       }
-      ThumbRef.current.style.left = `${clickedPos - 8}px`;
-      FilledRef.current.style.width = `${clickedPos - 24}px`;
+      ThumbRef.current.style.left = `${clickedPos - thumbWidth / 2}px`;
+      FilledRef.current.style.width = `${
+        clickedPos - thumbWidth - thumbWidth / 2
+      }px`;
       context.setValue(
         calcRangeValue(
-          context.size - 16,
+          context.size - thumbWidth,
           context.max,
           context.min,
-          maxXPosRef.current + 8,
+          maxXPosRef.current + thumbWidth / 2,
           clickedPos,
         ),
       );
@@ -142,7 +144,7 @@ const Slider = () => {
       minXPosRef.current = left + width / 2;
       maxXPosRef.current = right - width / 2;
       const initialPos = setInitialThumbPos(max, min, right, left, value);
-      ThumbRef.current.style.left = initialPos + 16 + 'px';
+      ThumbRef.current.style.left = initialPos + width + 'px';
       FilledRef.current.style.width = initialPos + 'px';
     }
   }, []);

--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -4,6 +4,8 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import {
   createContext,
+  MouseEvent,
+  MouseEventHandler,
   ReactNode,
   useContext,
   useEffect,
@@ -92,6 +94,15 @@ const Slider = () => {
       : 0;
   }, [ThumbRef.current]);
 
+  const handleThumbPosition = (
+    e: MouseEvent<HTMLDivElement> | globalThis.MouseEvent,
+  ) => {
+    if (ThumbRef.current && FilledRef.current && TrackRef.current && context) {
+      ThumbRef.current.style.left = `${e.clientX - thumbHalfWidth}px`;
+      FilledRef.current.style.width = `${e.clientX - thumbHalfWidth}px`;
+    }
+  };
+
   useLayoutEffect(() => {
     if (TrackRef.current?.getBoundingClientRect()) {
       const { left, right } = TrackRef.current.getBoundingClientRect();
@@ -115,15 +126,7 @@ const Slider = () => {
         if (!movable) return;
         if (e.clientX > maxXPosRef.current) return;
         if (e.clientX < minXPosRef.current) return;
-        if (
-          ThumbRef.current &&
-          FilledRef.current &&
-          TrackRef.current &&
-          context
-        ) {
-          ThumbRef.current.style.left = `${e.clientX - thumbHalfWidth}px`;
-          FilledRef.current.style.width = `${e.clientX - thumbHalfWidth}px`;
-        }
+        handleThumbPosition(e);
       },
       { signal },
     );
@@ -132,8 +135,12 @@ const Slider = () => {
   if (context === null) return null;
   return (
     <Flexbox>
-      <Track ref={TrackRef} size={context.size} />
-      <Filled ref={FilledRef} size={context.size} />
+      <Track ref={TrackRef} size={context.size} onClick={handleThumbPosition} />
+      <Filled
+        ref={FilledRef}
+        size={context.size}
+        onClick={handleThumbPosition}
+      />
       <Thumb ref={ThumbRef} onMouseDown={() => setMovable(true)}>
         <Flexbox justifyContent={'center'} alignItems={'center'}>
           <Typography variant={'desc'}>{context.value.toString()}</Typography>
@@ -145,6 +152,7 @@ const Slider = () => {
 
 interface TrackProps {
   size: number;
+  onClick: MouseEventHandler<HTMLDivElement>;
 }
 
 const Track = styled.div<TrackProps>`


### PR DESCRIPTION
## 🤠 개요

- #53 
- RangeSelector 컴포넌트를 구현합니다. 

## 💫 설명

- Compound Component 방식으로 만들어보고 싶어서 Context API를 사용했습니다. 처음 시도해보는데 꽤 많이 어려웠습니다. 🤯

- 일단 아직 부족한 부분이 많은데, 계속 붙잡고 있으면 다른 일 처리 못할까봐 RP 올려두고 차차 필요한 부분 덧붙이겠습니다. 

- 수많은 Ref가 존재하는데, DOM을 건드리는 작업 + 좌표를 고정적으로 저장하고 싶어서 그랬습니다. 
  뭔가 더 좋은 방법이 있을 것 같은데 알려주세요 🙏

- 접근성을 위해서 [MDN 의 Slider](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role) 를 참고하여 aria 속성을 부여했습니다. 

- useLayoutEffect 에서 Ref 관련 정보들을 먼저 다 받은 뒤에 해당 값들을 사용합니다. 근데 Ref.current 값이 없을 수도 있어서 조건문에서
  계속 값이 있는지 확인해주고 있습니다. Early return 하는 방식으로 바꿀까도 싶습니다. 

- useEffect 에서 등록하는 마우스 이벤트는 AbortController 를 사용해서 remove 하는 방식을 사용해보았습니다.

- RangeSelector 인데 현재는 Single Slider 라고 보시면 될 것 같습니다. 가능하다면 Props를 통해서 Double Thumb를 생성하도록 
  해보겠습니다. 개인적으로는 후술할 추가 작업 내용들 중에서 가장 우선순위가 낮다고 생각합니다. 
  <del>(만약 못만들면 이름을 RangeSlider 로 개명..)</del>

- Range (최대 최소 값의 차) 와 실제 Window 좌표를 비율로 계산해서 맞춰주려고 일반 함수들을 작성했습니다. 
  저에게는 너무 어려운 수학이었습니다. 지금은 호출할 때마다 모든 값을 다 전달하고 있는데 lint에 의해 가독성도 떨어지고 해서 Closer 를 
  이용하여 해결해 볼 계획입니다.

- Value 가 표시되는 부분에 대해서는 숫자가 커질수록 Thumb의 크기 때문에 문제가 될 수 있을 것 같은데 추후에 Tooltip 같은 컴포넌트를 
  만들게 된다면 Hover 했을 때에만 표시하는 방향을 염두에 두고 있습니다. 

- 키보드 이벤트로 조절할 수 있게 하려고 합니다. 이벤트 핸들러는 만들어놓았는데, 작성하다보니까 코드가 점점 더러워져서 Util 함수까지 
  구상하고나서 합쳐보겠습니다. 

- 지금 코드를 index.ts 파일 안에 모두 다 구현해놓았는데 😓 세세하게 분리하려다가 도중에 멈췄습니다. 이유는 Slider 컴포넌트 안에 있는 
  태그들을 분리할 때 적절한 컴포넌트 이름이 생각나지 않았기 때문입니다. 
  ex) Track 태그를 컴포넌트로 분리한다고 했을 때, 내부에 위치할 스타일 컴포넌트 이름은 무엇으로 해야하는지 등등

- 적다 보니까 이게 PR인지 이슈인지 참 모르겠지만~ 계속 조금씩 다듬어 보겠습니다. 귀한 리뷰 감사합니다. 🙇‍♂️


## 📷 스크린샷 (Optional)

#### 생성한 스토리 중에서 마지막 스토리 시연 영상입니다. 

https://user-images.githubusercontent.com/31645195/225994184-93f4382c-9689-421d-9559-ec407b94c50c.mov

