### PR TITLE
Feat/tabs: Tabs 컴포넌트 구현 

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -111,3 +111,25 @@ export const WithDisabled = WithDisabledTemplate.bind({});
 WithDisabled.args = {
   defaultValue: '1',
 };
+
+const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
+  <Tabs {...args}>
+    <Tabs.List>
+      <Tabs.Trigger value="1">
+        축하하는 탭을 띄우기 위한 트리거입니다.
+      </Tabs.Trigger>
+      <Tabs.Trigger value="2">
+        정보를 표시하기 위해서 여기를 클릭하세요.
+      </Tabs.Trigger>
+      <Tabs.Trigger value="3">아무튼 길어지면 스크롤이 생기겠죠?</Tabs.Trigger>
+      <Tabs.Trigger value="4">
+        여기까지 보이시면 너비를 줄여주시겠어요?
+      </Tabs.Trigger>
+    </Tabs.List>
+  </Tabs>
+);
+
+export const Scrollable = ScrollableTemplate.bind({});
+Scrollable.args = {
+  defaultValue: '1',
+};

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,113 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { MdCelebration, MdInfo, MdCheckCircle } from 'react-icons/md';
+
+import Tabs from '.';
+
+export default {
+  title: 'Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Tabs>;
+
+const DUMMY_STR_1 =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Est velit egestas dui id ornare arcu odio. Aliquet nibh praesent tristique magna sit. Mollis aliquam ut porttitor leo a diam sollicitudin. Diam maecenas sed enim ut sem viverra aliquet. Lorem ipsum dolor sit amet consectetur adipiscing. Lacinia at quis risus sed vulputate odio ut. Faucibus ornare suspendisse sed nisi lacus sed viverra. Vulputate enim nulla aliquet porttitor. Nunc vel risus commodo viverra maecenas. Nec feugiat in fermentum posuere urna nec tincidunt praesent semper. Netus et malesuada fames ac turpis egestas maecenas pharetra convallis. Condimentum vitae sapien pellentesque habitant morbi tristique senectus et netus. Lacus vestibulum sed arcu non odio euismod. Elit pellentesque habitant morbi tristique senectus et netus et. Dui accumsan sit amet nulla facilisi morbi tempus. Libero nunc consequat interdum varius sit amet mattis vulputate. Ultricies integer quis auctor elit sed vulputate mi. Aliquam purus sit amet luctus.';
+const DUMMY_STR_2 =
+  'Ut porttitor leo a diam sollicitudin tempor. Mattis aliquam faucibus purus in massa tempor nec feugiat. Congue eu consequat ac felis. Sed adipiscing diam donec adipiscing tristique risus nec feugiat in. Euismod in pellentesque massa placerat duis ultricies lacus sed turpis. Metus aliquam eleifend mi in nulla posuere sollicitudin. Arcu dui vivamus arcu felis bibendum ut tristique. Magna etiam tempor orci eu lobortis elementum nibh tellus. Euismod nisi porta lorem mollis aliquam ut porttitor leo a. Nisl tincidunt eget nullam non nisi est sit amet. Ut consequat semper viverra nam libero justo laoreet sit. Quis risus sed vulputate odio ut enim. Tincidunt ornare massa eget egestas. Id cursus metus aliquam eleifend. Blandit cursus risus at ultrices mi. Arcu cursus vitae congue mauris rhoncus aenean vel. Arcu risus quis varius quam quisque id.';
+const DUMMY_STR_3 =
+  'Enim diam vulputate ut pharetra sit amet. Amet mauris commodo quis imperdiet massa tincidunt nunc. Venenatis cras sed felis eget velit aliquet. Suspendisse interdum consectetur libero id. Ut tortor pretium viverra suspendisse potenti nullam ac tortor vitae. Sit amet cursus sit amet dictum sit amet justo donec. Consequat mauris nunc congue nisi vitae. Cras tincidunt lobortis feugiat vivamus at augue eget arcu. Nullam eget felis eget nunc lobortis mattis. Tortor posuere ac ut consequat. Ornare arcu odio ut sem. Ante metus dictum at tempor commodo ullamcorper a lacus. Ut porttitor leo a diam sollicitudin. At imperdiet dui accumsan sit amet nulla facilisi morbi tempus. Mattis molestie a iaculis at erat. Ut eu sem integer vitae justo eget magna fermentum iaculis. Quam adipiscing vitae proin sagittis nisl.';
+
+const Template: ComponentStory<typeof Tabs> = (args) => (
+  <Tabs {...args}>
+    <Tabs.List>
+      <Tabs.Trigger value="1">메인</Tabs.Trigger>
+      <Tabs.Trigger value="2">이벤트</Tabs.Trigger>
+      <Tabs.Trigger value="3">설정</Tabs.Trigger>
+    </Tabs.List>
+    <Tabs.Panel value="1">
+      <span>첫번째 탭</span>
+      <div>{DUMMY_STR_1}</div>
+    </Tabs.Panel>
+    <Tabs.Panel value="2">
+      <span>두번째 탭</span>
+      <div>{DUMMY_STR_2}</div>
+    </Tabs.Panel>
+    <Tabs.Panel value="3">
+      <span>세번째 탭</span>
+      <div>{DUMMY_STR_3}</div>
+    </Tabs.Panel>
+  </Tabs>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  defaultValue: '1',
+};
+
+export const Rounded = Template.bind({});
+Rounded.args = {
+  defaultValue: '1',
+  variant: 'rounded',
+};
+
+export const UnderlineFitted = Template.bind({});
+UnderlineFitted.args = {
+  defaultValue: '1',
+  variant: 'underline',
+  isFitted: true,
+};
+
+export const RoundedFitted = Template.bind({});
+RoundedFitted.args = {
+  defaultValue: '1',
+  variant: 'rounded',
+  isFitted: true,
+};
+
+export const DefaultValue = Template.bind({});
+DefaultValue.args = {
+  defaultValue: '3',
+};
+
+const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
+  <Tabs {...args}>
+    <Tabs.List>
+      <Tabs.Trigger value="1" icon={MdCelebration}>
+        축하
+      </Tabs.Trigger>
+      <Tabs.Trigger value="2" icon={MdInfo}>
+        정보
+      </Tabs.Trigger>
+      <Tabs.Trigger value="3" icon={MdCheckCircle}>
+        확인
+      </Tabs.Trigger>
+    </Tabs.List>
+  </Tabs>
+);
+
+export const WithIcons = WithIconsTemplate.bind({});
+WithIcons.args = {
+  defaultValue: '1',
+};
+
+const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
+  <Tabs {...args}>
+    <Tabs.List>
+      <Tabs.Trigger value="1" icon={MdCelebration}>
+        축하
+      </Tabs.Trigger>
+      <Tabs.Trigger value="2" icon={MdInfo} disabled>
+        정보
+      </Tabs.Trigger>
+      <Tabs.Trigger value="3" icon={MdCheckCircle}>
+        확인
+      </Tabs.Trigger>
+    </Tabs.List>
+  </Tabs>
+);
+
+export const WithDisabled = WithDisabledTemplate.bind({});
+WithDisabled.args = {
+  defaultValue: '1',
+};

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -33,10 +33,27 @@ const Tabs = ({ defaultValue, children }: TabsProps) => {
 
 interface TabListProps {
   children: ReactNode;
+  isFitted?: boolean;
 }
 
-const List = ({ children }: TabListProps) => {
-  return <Flexbox>{children}</Flexbox>;
+const List = ({ isFitted = false, children }: TabListProps) => {
+  return (
+    <Container overflowX="auto">
+      <Flexbox
+        justifyContent={'flex-start'}
+        css={css`
+          width: ${isFitted === false && 'max-content'};
+
+          & > button {
+            width: ${isFitted === true && '100%'};
+            white-space: nowrap;
+          }
+        `}
+      >
+        {children}
+      </Flexbox>
+    </Container>
+  );
 };
 
 interface TabTriggerProps {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button';
 import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
 import { css } from '@emotion/react';
@@ -19,7 +20,13 @@ const Tabs = ({ defaultValue, children }: TabsProps) => {
 
   return (
     <TabsContext.Provider value={{ selectedIndex, setSelectedIndex }}>
-      {children}
+      <Container
+        css={css`
+          padding: 1rem;
+        `}
+      >
+        {children}
+      </Container>
     </TabsContext.Provider>
   );
 };
@@ -35,14 +42,19 @@ const List = ({ children }: TabListProps) => {
 interface TabTriggerProps {
   value: string;
   children: ReactNode;
+  disabled?: boolean;
 }
 
-const Trigger = ({ value, children }: TabTriggerProps) => {
+const Trigger = ({ value, disabled = false, children }: TabTriggerProps) => {
   const context = useContext(TabsContext);
 
   if (context === null) return null;
   return (
-    <button onClick={() => context.setSelectedIndex(value)}>{children}</button>
+    <Button
+      text={children?.toString()}
+      disabled={disabled}
+      onClick={() => context.setSelectedIndex(value)}
+    />
   );
 };
 
@@ -59,8 +71,8 @@ const Content = ({ value, children }: TabContentProps) => {
   return (
     <Container
       css={css`
+        padding: 1rem;
         display: ${context.selectedIndex === value ? 'block' : 'none'};
-        color: red;
       `}
     >
       {children}

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,0 +1,75 @@
+import Container from '@components-layout/Container';
+import Flexbox from '@components-layout/Flexbox';
+import { css } from '@emotion/react';
+import { createContext, ReactNode, useContext, useState } from 'react';
+
+const TabsContext =
+  createContext<{
+    selectedIndex: string;
+    setSelectedIndex: React.Dispatch<React.SetStateAction<string>>;
+  } | null>(null);
+
+interface TabsProps {
+  defaultValue: string;
+  children: ReactNode;
+}
+
+const Tabs = ({ defaultValue, children }: TabsProps) => {
+  const [selectedIndex, setSelectedIndex] = useState<string>(defaultValue);
+
+  return (
+    <TabsContext.Provider value={{ selectedIndex, setSelectedIndex }}>
+      {children}
+    </TabsContext.Provider>
+  );
+};
+
+interface TabListProps {
+  children: ReactNode;
+}
+
+const List = ({ children }: TabListProps) => {
+  return <Flexbox>{children}</Flexbox>;
+};
+
+interface TabTriggerProps {
+  value: string;
+  children: ReactNode;
+}
+
+const Trigger = ({ value, children }: TabTriggerProps) => {
+  const context = useContext(TabsContext);
+
+  if (context === null) return null;
+  return (
+    <button onClick={() => context.setSelectedIndex(value)}>{children}</button>
+  );
+};
+
+interface TabContentProps {
+  value: string;
+  children: ReactNode;
+}
+
+const Content = ({ value, children }: TabContentProps) => {
+  const context = useContext(TabsContext);
+
+  if (context === null) return null;
+
+  return (
+    <Container
+      css={css`
+        display: ${context.selectedIndex === value ? 'block' : 'none'};
+        color: red;
+      `}
+    >
+      {children}
+    </Container>
+  );
+};
+
+Tabs.List = List;
+Tabs.Trigger = Trigger;
+Tabs.Content = Content;
+
+export default Tabs;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,7 +1,9 @@
 import Button from '@components/Button';
+import { IconSource } from '@components/Icon';
 import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
 import { css, useTheme } from '@emotion/react';
+import { pixelToRem } from '@utils/pixelToRem';
 import { createContext, ReactNode, useContext, useState } from 'react';
 
 type TabListVariant = 'underline' | 'rounded';
@@ -80,14 +82,21 @@ interface TabTriggerProps {
   value: string;
   children: ReactNode;
   disabled?: boolean;
+  icon?: IconSource;
 }
 
-const Trigger = ({ value, disabled = false, children }: TabTriggerProps) => {
+const Trigger = ({
+  value,
+  disabled = false,
+  icon,
+  children,
+}: TabTriggerProps) => {
   const context = useContext(TabsContext);
   if (context === null) return null;
 
   const { color: themeColor } = useTheme();
   const { primary100, gray100, black, white } = themeColor;
+  const isActive = context.selectedIndex === value;
 
   const underlineStyle = {
     borderColor: `${context.selectedIndex === value ? primary100 : gray100}`,
@@ -115,12 +124,18 @@ const Trigger = ({ value, disabled = false, children }: TabTriggerProps) => {
     <Button
       text={children?.toString()}
       disabled={disabled}
+      icon={icon}
+      iconSize={pixelToRem('16px')}
       onClick={() => context.setSelectedIndex(value)}
       css={css`
         ${triggerStyles[context.variant]}
 
         & > p {
-          color: ${context.selectedIndex === value ? primary100 : black};
+          color: ${isActive ? primary100 : black};
+        }
+
+        & > svg {
+          fill: ${isActive ? primary100 : black};
         }
 
         &:hover {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -57,7 +57,16 @@ const List = ({ children }: TabListProps) => {
 
   if (context === null) return null;
   return (
-    <Container overflowX="auto">
+    <Container
+      overflowX="auto"
+      css={css`
+        -ms-overflow-style: none;
+
+        ::-webkit-scrollbar {
+          display: none;
+        }
+      `}
+    >
       <Flexbox
         justifyContent={'flex-start'}
         css={css`

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -90,20 +90,20 @@ const Trigger = ({ value, disabled = false, children }: TabTriggerProps) => {
   const { primary100, gray100, black, white } = themeColor;
 
   const underlineStyle = {
-    'border-color': `${context.selectedIndex === value ? primary100 : gray100}`,
-    'border-radius': 0,
-    'border-bottom-width': '2px',
-    'border-bottom-style': 'solid',
-    'margin-bottom': '-2px',
+    borderColor: `${context.selectedIndex === value ? primary100 : gray100}`,
+    borderRadius: 0,
+    borderBottomWidth: '2px',
+    borderBottomStyle: 'solid',
+    marginBottom: '-2px',
   } as const;
 
   const roundedStyle = {
     border: `${context.selectedIndex === value && `2px ${gray100} solid`}`,
-    'border-radius': '10px',
-    'border-bottom-left-radius': 0,
-    'border-bottom-right-radius': 0,
-    'border-bottom-color': `${white}`,
-    'margin-bottom': '-2px',
+    borderRadius: '10px',
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    borderBottomColor: `${white}`,
+    marginBottom: '-2px',
   } as const;
 
   const triggerStyles = {

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -6,12 +6,12 @@ import { css, useTheme } from '@emotion/react';
 import { pixelToRem } from '@utils/pixelToRem';
 import { createContext, ReactNode, useContext, useState } from 'react';
 
-type TabListVariant = 'underline' | 'rounded';
+type TabsVariant = 'underline' | 'rounded';
 
 const TabsContext =
   createContext<{
     isFitted: boolean;
-    variant: TabListVariant;
+    variant: TabsVariant;
     selectedIndex: string;
     setSelectedIndex: React.Dispatch<React.SetStateAction<string>>;
   } | null>(null);
@@ -19,7 +19,7 @@ const TabsContext =
 interface TabsProps {
   defaultValue: string;
   children: ReactNode;
-  variant?: TabListVariant;
+  variant?: TabsVariant;
   isFitted?: boolean;
 }
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -4,17 +4,25 @@ import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
 import { css, useTheme } from '@emotion/react';
 import { pixelToRem } from '@utils/pixelToRem';
-import { createContext, ReactNode, useContext, useState } from 'react';
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useContext,
+  useState,
+} from 'react';
 
 type TabsVariant = 'underline' | 'rounded';
 
-const TabsContext =
-  createContext<{
-    isFitted: boolean;
-    variant: TabsVariant;
-    selectedIndex: string;
-    setSelectedIndex: React.Dispatch<React.SetStateAction<string>>;
-  } | null>(null);
+interface TabsContextInterface {
+  isFitted: boolean;
+  variant: TabsVariant;
+  selectedIndex: string;
+  setSelectedIndex: Dispatch<SetStateAction<string>>;
+}
+
+const TabsContext = createContext<TabsContextInterface | null>(null);
 
 interface TabsProps {
   defaultValue: string;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -164,7 +164,7 @@ const Trigger = ({
             fill: ${gray100};
           }
 
-          &: hover {
+          &:hover {
             border-bottom-color: ${gray100};
           }
         }

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -126,7 +126,7 @@ const Trigger = ({
       disabled={disabled}
       icon={icon}
       iconSize={pixelToRem('16px')}
-      onClick={() => context.setSelectedIndex(value)}
+      onClick={() => !disabled && context.setSelectedIndex(value)}
       css={css`
         ${triggerStyles[context.variant]}
 
@@ -141,6 +141,23 @@ const Trigger = ({
         &:hover {
           background-color: ${primary100};
           border-bottom-color: ${primary100};
+        }
+
+        &:disabled {
+          background-color: ${white};
+          cursor: not-allowed;
+
+          & > p {
+            color: ${gray100};
+          }
+
+          & > svg {
+            fill: ${gray100};
+          }
+
+          &: hover {
+            border-bottom-color: ${gray100};
+          }
         }
       `}
     />

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -147,12 +147,12 @@ const Trigger = ({
   );
 };
 
-interface TabContentProps {
+interface TabPanelProps {
   value: string;
   children: ReactNode;
 }
 
-const Content = ({ value, children }: TabContentProps) => {
+const Panel = ({ value, children }: TabPanelProps) => {
   const context = useContext(TabsContext);
 
   if (context === null) return null;
@@ -171,6 +171,6 @@ const Content = ({ value, children }: TabContentProps) => {
 
 Tabs.List = List;
 Tabs.Trigger = Trigger;
-Tabs.Content = Content;
+Tabs.Panel = Panel;
 
 export default Tabs;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,11 +1,15 @@
 import Button from '@components/Button';
 import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 import { createContext, ReactNode, useContext, useState } from 'react';
+
+type TabListVariant = 'underline' | 'rounded';
 
 const TabsContext =
   createContext<{
+    isFitted: boolean;
+    variant: TabListVariant;
     selectedIndex: string;
     setSelectedIndex: React.Dispatch<React.SetStateAction<string>>;
   } | null>(null);
@@ -13,13 +17,22 @@ const TabsContext =
 interface TabsProps {
   defaultValue: string;
   children: ReactNode;
+  variant?: TabListVariant;
+  isFitted?: boolean;
 }
 
-const Tabs = ({ defaultValue, children }: TabsProps) => {
+const Tabs = ({
+  isFitted = false,
+  variant = 'underline',
+  defaultValue,
+  children,
+}: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = useState<string>(defaultValue);
 
+  const providerValue = { isFitted, variant, selectedIndex, setSelectedIndex };
+
   return (
-    <TabsContext.Provider value={{ selectedIndex, setSelectedIndex }}>
+    <TabsContext.Provider value={providerValue}>
       <Container
         css={css`
           padding: 1rem;
@@ -33,20 +46,27 @@ const Tabs = ({ defaultValue, children }: TabsProps) => {
 
 interface TabListProps {
   children: ReactNode;
-  isFitted?: boolean;
 }
 
-const List = ({ isFitted = false, children }: TabListProps) => {
+const List = ({ children }: TabListProps) => {
+  const context = useContext(TabsContext);
+  const { color: themeColor } = useTheme();
+  const { white, gray100 } = themeColor;
+
+  if (context === null) return null;
   return (
     <Container overflowX="auto">
       <Flexbox
         justifyContent={'flex-start'}
         css={css`
-          width: ${isFitted === false && 'max-content'};
+          gap: 0;
+          width: 100%;
+          border-bottom: 2px solid ${gray100};
 
           & > button {
-            width: ${isFitted === true && '100%'};
+            width: ${context.isFitted === true && '100%'};
             white-space: nowrap;
+            background-color: ${white};
           }
         `}
       >
@@ -64,13 +84,50 @@ interface TabTriggerProps {
 
 const Trigger = ({ value, disabled = false, children }: TabTriggerProps) => {
   const context = useContext(TabsContext);
-
   if (context === null) return null;
+
+  const { color: themeColor } = useTheme();
+  const { primary100, gray100, black, white } = themeColor;
+
+  const underlineStyle = {
+    'border-color': `${context.selectedIndex === value ? primary100 : gray100}`,
+    'border-radius': 0,
+    'border-bottom-width': '2px',
+    'border-bottom-style': 'solid',
+    'margin-bottom': '-2px',
+  } as const;
+
+  const roundedStyle = {
+    border: `${context.selectedIndex === value && `2px ${gray100} solid`}`,
+    'border-radius': '10px',
+    'border-bottom-left-radius': 0,
+    'border-bottom-right-radius': 0,
+    'border-bottom-color': `${white}`,
+    'margin-bottom': '-2px',
+  } as const;
+
+  const triggerStyles = {
+    underline: underlineStyle,
+    rounded: roundedStyle,
+  };
+
   return (
     <Button
       text={children?.toString()}
       disabled={disabled}
       onClick={() => context.setSelectedIndex(value)}
+      css={css`
+        ${triggerStyles[context.variant]}
+
+        & > p {
+          color: ${context.selectedIndex === value ? primary100 : black};
+        }
+
+        &:hover {
+          background-color: ${primary100};
+          border-bottom-color: ${primary100};
+        }
+      `}
     />
   );
 };


### PR DESCRIPTION
## 🤠 개요

- #62 
- 이슈에 첨부한 자료를 참고하여 Tabs 컴포넌트를 구현합니다. 

## 💫 설명

- Tabs 컴포넌트를 구현합니다. 

- Compound Component 로 구현했으며 각각 List, Trigger, Panel 로 구분됩니다. 

  - Trigger : 사용자가 클릭하는 부분을 말합니다. 

  - List : Trigger 부분을 Wrapping 하는 컴포넌트입니다. 

  - Panel : 클릭한 Trigger에 대응하는 컴포넌트를 렌더링하기 위한 Wrapper 컴포넌트입니다. 

- Context 에서 공유하는 데이터 중 selectedIndex 를 토대로 Panel 이 변경됩니다. 

  - 따라서 알맞은 컴포넌트를 렌더링하기 위해서 Trigger 와 Panel 에 전달하는 value 값이 동일해야 합니다. 
    ( 자세한 부분은 스토리를 참고해주세요 )

- 최상위 Tabs에 Props 로 전달하는 값에 따라 달라지는 부분이 있습니다. 

  - defaultValue : 초기에 렌더링할 Panel 을 선택합니다. Panel 에 전달하는 value 와 동일해야 합니다. 

  - isFitted : Trigger 들의 너비를 늘릴 수 있는 boolean 값입니다. 

  - variant : 'underline' 과 'rounded' 값이 주어지며, 이에 따라 Trigger 디자인이 달라집니다. ( default 는 underline 입니다 )

- Trigger 에 넣을 수 있는 **_선택적인_** props 는 다음과 같습니다. 

  - icon : 아이콘을 넣을 수 있습니다. 

  - disabled : Trigger 를 비활성화할 수 있습니다. 

- 위에서 설명한 부분은 모두 스토리에서 확인하실 수 있습니다. 

- 추가로 작업해야 하는 부분은 아래와 같습니다. 

  - 키보드를 사용하여 Tab 을 이동할 수 있도록 tabIndex 설정과 키보드 이벤트 핸들러 등록 

  - 이슈에서 첨부했던 글을 기반으로 접근성 관련 속성 적용 

<del> - 질문 : 아이콘만 넣을 수 있는 Tab이 필요할까요? 만들면 모바일 퍼스트를 고려했을 때 좋을 것 같기도 합니다. PR 메세지 적으면서 생각났어요 </del>
- 답 : Trigger에 text 를 넣지 않으면 되니까 그렇게 쓰도록 해요! 😅

- 단상 : Button 을 활용해보고 싶어서 가져다가 쓰긴 했는데, 외형은 거의 새로 정의한거나 다름 없어서 조금 찝찝해요. 그래도 props 를 최대한 활용해보려고 시도해보았어요. (아이콘 등)

- 🤔 : 탭을 눌렀을 때 클릭한 Trigger를 가장 좌측으로 움직여주는 그런 기능도 있으면 좋겠죠..?