### PR TITLE
Feat/select: Select 컴포넌트 구현

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,7 +1,7 @@
 import Container from '@components-layout/Container';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { DefaultProps } from '@util-types/DefaultProps';
+import { ChildrenProps } from '@util-types/ChildrenProps';
 import {
   createContext,
   Dispatch,
@@ -13,11 +13,12 @@ import {
   useState,
 } from 'react';
 
-interface DropdownProps extends DefaultProps<HTMLDivElement> {
+type DropdownProps = {
+  id: string;
+  dropdownLabel: string;
   collapseOnBlur: boolean;
-  dropdownLabel?: string;
   direction?: 'left' | 'right' | 'top' | 'bottom';
-}
+} & ChildrenProps;
 
 interface DropdownContextInterface {
   isOpen: boolean;
@@ -40,9 +41,9 @@ interface DropdownContextInterface {
 const DropdownContext = createContext<DropdownContextInterface | null>(null);
 
 const Dropdown = ({
-  collapseOnBlur = false,
-  dropdownLabel = '',
   id = '',
+  dropdownLabel = '',
+  collapseOnBlur = false,
   direction = 'bottom',
   children,
 }: DropdownProps) => {
@@ -79,7 +80,7 @@ const Dropdown = ({
   );
 };
 
-const Trigger = ({ children }: DefaultProps<HTMLDivElement>) => {
+const Trigger = ({ children }: ChildrenProps) => {
   const context = useContext(DropdownContext);
   const triggerRef = useRef<HTMLDivElement | null>(null);
 
@@ -112,7 +113,7 @@ const Trigger = ({ children }: DefaultProps<HTMLDivElement>) => {
   );
 };
 
-const Menu = ({ children }: DefaultProps<HTMLDivElement>) => {
+const Menu = ({ children }: ChildrenProps) => {
   const context = useContext(DropdownContext);
   const menuRef = useRef<HTMLDivElement | null>(null);
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -11,14 +11,31 @@ export default {
   component: Select,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle: 'HTML select 태그의 기능을 제공합니다.',
+  },
+  argTypes: {
+    id: {
+      label: 'id',
+      type: {
+        name: 'string',
+        required: true,
+      },
+      description:
+        'select 요소의 id입니다. 어떤 값인지 드러나는 이름이면 좋습니다.',
+    },
+    setValue: {
+      label: 'setValue',
+      description:
+        'setState 함수입니다. 옵션 A가 선택되는 경우 setValue(A)가 실행됩니다. 옵셔널 props입니다.',
+    },
   },
 } as ComponentMeta<typeof Select>;
 
-export const UseState: ComponentStory<typeof Select> = () => {
+export const Template: ComponentStory<typeof Select> = (args) => {
   const [value, setValue] = useState('');
 
   return (
-    <Select id="test" setValue={setValue}>
+    <Select {...args} setValue={setValue}>
       <Select.Trigger>
         <Badge outline>{value ? value : 'click here'}</Badge>
       </Select.Trigger>
@@ -29,6 +46,20 @@ export const UseState: ComponentStory<typeof Select> = () => {
       </Select.Options>
     </Select>
   );
+};
+Template.args = {
+  id: 'template',
+};
+
+export const UseState = Template.bind({});
+UseState.args = {
+  id: 'useState',
+};
+UseState.parameters = {
+  docs: {
+    storyDescription:
+      '선택 결과를 상태에 반영하고 싶은 경우 props.setValue에 setState 함수를 전달합니다.',
+  },
 };
 
 const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
@@ -46,7 +77,7 @@ export const Form: ComponentStory<typeof Select> = () => {
 
   return (
     <form onSubmit={onSubmit} css={flexboxStyle()}>
-      <Select id="test" setValue={setValue}>
+      <Select id="form" setValue={setValue}>
         <Select.Trigger>
           <Badge outline>{value ? value : 'click here'}</Badge>
         </Select.Trigger>
@@ -60,6 +91,12 @@ export const Form: ComponentStory<typeof Select> = () => {
     </form>
   );
 };
+Form.parameters = {
+  docs: {
+    storyDescription:
+      'HTML form 요소 내부에서 사용하면 FormData API를 활용해 값을 가져올 수 있습니다. 이 때 select 요소는 props.id와 동일한 name을 가집니다.',
+  },
+};
 
 export const MultipleSelects: ComponentStory<typeof Select> = () => {
   const [value, setValue] = useState('');
@@ -67,7 +104,7 @@ export const MultipleSelects: ComponentStory<typeof Select> = () => {
 
   return (
     <form onSubmit={onSubmit} css={flexboxStyle()}>
-      <Select id="test" setValue={setValue}>
+      <Select id="select" setValue={setValue}>
         <Select.Trigger>
           <Badge outline>{value ? value : 'click here'}</Badge>
         </Select.Trigger>
@@ -92,4 +129,10 @@ export const MultipleSelects: ComponentStory<typeof Select> = () => {
       <Button text="submit" />
     </form>
   );
+};
+MultipleSelects.parameters = {
+  docs: {
+    storyDescription:
+      '서로 다른 id를 가지는 여러 개의 select를 사용할 수 있습니다.',
+  },
 };

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,0 +1,95 @@
+import Badge from '@components/Badge';
+import Button from '@components/Button';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { flexboxStyle } from '@styles/flex-box';
+import { FormEventHandler, useState } from 'react';
+
+import Select from '.';
+
+export default {
+  title: 'Select',
+  component: Select,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} as ComponentMeta<typeof Select>;
+
+export const UseState: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <Select id="test" setValue={setValue}>
+      <Select.Trigger>
+        <Badge outline>{value ?? 'click here'}</Badge>
+      </Select.Trigger>
+      <Select.Options>
+        <Select.Option value="1">1</Select.Option>
+        <Select.Option value="2">2</Select.Option>
+        <Select.Option value="3">3</Select.Option>
+      </Select.Options>
+    </Select>
+  );
+};
+
+const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  e.preventDefault();
+
+  const target = e.target as HTMLFormElement;
+  if (!target) return;
+
+  const formData = new FormData(target);
+  console.log(...formData.entries()); // 확인용 로그
+};
+
+export const Form: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState<string | null>(null);
+
+  return (
+    <form onSubmit={onSubmit} css={flexboxStyle()}>
+      <Select id="test" setValue={setValue}>
+        <Select.Trigger>
+          <Badge outline>{value ?? 'click here'}</Badge>
+        </Select.Trigger>
+        <Select.Options>
+          <Select.Option value="1">1</Select.Option>
+          <Select.Option value="2">2</Select.Option>
+          <Select.Option value="3">3</Select.Option>
+        </Select.Options>
+      </Select>
+      <Button text="submit" />
+    </form>
+  );
+};
+
+export const MultipleSelects: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState<string | null>(null);
+  const [anotherValue, setAnotherValue] = useState<string | null>(null);
+
+  return (
+    <form onSubmit={onSubmit} css={flexboxStyle()}>
+      <Select id="test" setValue={setValue}>
+        <Select.Trigger>
+          <Badge outline>{value ?? 'click here'}</Badge>
+        </Select.Trigger>
+        <Select.Options>
+          <Select.Option value="1">1</Select.Option>
+          <Select.Option value="2">2</Select.Option>
+          <Select.Option value="3">3</Select.Option>
+        </Select.Options>
+      </Select>
+
+      <Select id="another" setValue={setAnotherValue}>
+        <Select.Trigger>
+          <Badge outline>{anotherValue ?? 'click here'}</Badge>
+        </Select.Trigger>
+        <Select.Options>
+          <Select.Option value="first">first</Select.Option>
+          <Select.Option value="second">second</Select.Option>
+          <Select.Option value="third">third</Select.Option>
+        </Select.Options>
+      </Select>
+
+      <Button text="submit" />
+    </form>
+  );
+};

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -15,12 +15,12 @@ export default {
 } as ComponentMeta<typeof Select>;
 
 export const UseState: ComponentStory<typeof Select> = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState('');
 
   return (
     <Select id="test" setValue={setValue}>
       <Select.Trigger>
-        <Badge outline>{value ?? 'click here'}</Badge>
+        <Badge outline>{value ? value : 'click here'}</Badge>
       </Select.Trigger>
       <Select.Options>
         <Select.Option value="1">1</Select.Option>
@@ -42,13 +42,13 @@ const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
 };
 
 export const Form: ComponentStory<typeof Select> = () => {
-  const [value, setValue] = useState<string | null>(null);
+  const [value, setValue] = useState('');
 
   return (
     <form onSubmit={onSubmit} css={flexboxStyle()}>
       <Select id="test" setValue={setValue}>
         <Select.Trigger>
-          <Badge outline>{value ?? 'click here'}</Badge>
+          <Badge outline>{value ? value : 'click here'}</Badge>
         </Select.Trigger>
         <Select.Options>
           <Select.Option value="1">1</Select.Option>
@@ -62,14 +62,14 @@ export const Form: ComponentStory<typeof Select> = () => {
 };
 
 export const MultipleSelects: ComponentStory<typeof Select> = () => {
-  const [value, setValue] = useState<string | null>(null);
-  const [anotherValue, setAnotherValue] = useState<string | null>(null);
+  const [value, setValue] = useState('');
+  const [anotherValue, setAnotherValue] = useState('');
 
   return (
     <form onSubmit={onSubmit} css={flexboxStyle()}>
       <Select id="test" setValue={setValue}>
         <Select.Trigger>
-          <Badge outline>{value ?? 'click here'}</Badge>
+          <Badge outline>{value ? value : 'click here'}</Badge>
         </Select.Trigger>
         <Select.Options>
           <Select.Option value="1">1</Select.Option>
@@ -80,7 +80,7 @@ export const MultipleSelects: ComponentStory<typeof Select> = () => {
 
       <Select id="another" setValue={setAnotherValue}>
         <Select.Trigger>
-          <Badge outline>{anotherValue ?? 'click here'}</Badge>
+          <Badge outline>{anotherValue ? anotherValue : 'click here'}</Badge>
         </Select.Trigger>
         <Select.Options>
           <Select.Option value="first">first</Select.Option>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -28,7 +28,11 @@ const Select = ({ id, setValue, children }: SelectProps) => {
   const { selectRef, selectValue, registerOption } = useSelect(id, setValue);
 
   return (
-    <Dropdown collapseOnBlur={true}>
+    <Dropdown
+      id={`${id}_select_dropdown`}
+      dropdownLabel={`Opens ${id} select`}
+      collapseOnBlur={true}
+    >
       <SelectContext.Provider value={{ selectValue, registerOption }}>
         {children}
       </SelectContext.Provider>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -10,7 +10,7 @@ import {
   useContext,
 } from 'react';
 
-import useOptions from './useOptions';
+import useSelect from './useSelect';
 
 type SelectProps = {
   id: string;
@@ -26,7 +26,7 @@ interface SelectContextInterface {
 const SelectContext = createContext<SelectContextInterface | null>(null);
 
 const Select = ({ id, setValue, children }: SelectProps) => {
-  const { selectRef, selectValue, registerOption } = useOptions(id, setValue);
+  const { selectRef, selectValue, registerOption } = useSelect(id, setValue);
 
   return (
     <Dropdown collapseOnBlur={true}>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,0 +1,91 @@
+import Dropdown from '@components/Dropdown';
+import { css } from '@emotion/react';
+import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  forwardRef,
+  useContext,
+} from 'react';
+
+import useOptions from './useOptions';
+
+type SelectProps = {
+  id: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setValue?: Dispatch<SetStateAction<any>>;
+  children: ReactNode;
+};
+
+interface SelectContextInterface {
+  selectValue: (value: string) => void;
+  registerOption: ($el: HTMLLIElement, value: string) => void;
+}
+const SelectContext = createContext<SelectContextInterface | null>(null);
+
+const Select = ({ id, setValue, children }: SelectProps) => {
+  const { selectRef, selectValue, registerOption } = useOptions(id, setValue);
+
+  return (
+    <Dropdown collapseOnBlur={true}>
+      <SelectContext.Provider value={{ selectValue, registerOption }}>
+        {children}
+      </SelectContext.Provider>
+      <HiddenSelect id={id} ref={selectRef} />
+    </Dropdown>
+  );
+};
+
+const Options = ({ children }: DefaultPropsWithChildren<HTMLLIElement>) => {
+  return (
+    <Dropdown.Menu>
+      <ul role="listbox">{children}</ul>
+    </Dropdown.Menu>
+  );
+};
+
+type OptionProps = {
+  value: string;
+} & DefaultPropsWithChildren<HTMLLIElement>;
+
+const Option = ({ value, children }: OptionProps) => {
+  const context = useContext(SelectContext);
+  if (!context) return <></>;
+
+  const { selectValue, registerOption } = context;
+
+  const refCallback = ($el: HTMLLIElement | null) => {
+    if (!$el) return;
+    registerOption($el, value);
+  };
+
+  return (
+    <li role="listitem" ref={refCallback} onClick={() => selectValue(value)}>
+      {children}
+    </li>
+  );
+};
+
+const HiddenSelect = forwardRef<HTMLSelectElement, { id: string }>(
+  ({ id }, ref) => {
+    return <select id={id} name={id} ref={ref} css={hiddenStyle}></select>;
+  },
+);
+const hiddenStyle = css`
+  position: absolute;
+  height: 0px;
+  width: 0px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clippath: inset(50%);
+  whitespace: nowrap;
+`;
+HiddenSelect.displayName = 'HiddenSelect';
+
+Select.Trigger = Dropdown.Trigger;
+Select.Options = Options;
+Select.Option = Option;
+
+export default Select;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -20,7 +20,7 @@ type SelectProps = {
 
 interface SelectContextInterface {
   selectValue: (value: string) => void;
-  registerOption: ($el: HTMLLIElement, value: string) => void;
+  registerOption: ($li: HTMLLIElement, value: string) => void;
 }
 const SelectContext = createContext<SelectContextInterface | null>(null);
 
@@ -55,14 +55,14 @@ const Option = ({ value, children }: OptionProps) => {
 
   const { selectValue, registerOption } = context;
 
-  const refCallback = ($el: HTMLLIElement | null) => {
-    if (!$el) return;
-    registerOption($el, value);
+  const refCallback = ($li: HTMLLIElement | null) => {
+    if (!$li) return;
+    registerOption($li, value);
   };
 
   const dropdownContext = useContext(DropdownContext);
   if (!dropdownContext) {
-    throw new Error('Select component must have its own Dropdown context');
+    return <></>;
   }
   const { setIsOpen } = dropdownContext;
 
@@ -77,9 +77,7 @@ const Option = ({ value, children }: OptionProps) => {
       ref={refCallback}
       onClick={onSelect}
       css={css`
-        &:hover {
-          cursor: pointer;
-        }
+        cursor: pointer;
       `}
     >
       {children}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,6 +1,6 @@
 import Dropdown, { DropdownContext } from '@components/Dropdown';
 import { css } from '@emotion/react';
-import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
+import { ChildrenProps } from '@util-types/ChildrenProps';
 import {
   Dispatch,
   ReactNode,
@@ -37,7 +37,7 @@ const Select = ({ id, setValue, children }: SelectProps) => {
   );
 };
 
-const Options = ({ children }: DefaultPropsWithChildren<HTMLLIElement>) => {
+const Options = ({ children }: ChildrenProps) => {
   return (
     <Dropdown.Menu>
       <ul role="listbox">{children}</ul>
@@ -47,7 +47,7 @@ const Options = ({ children }: DefaultPropsWithChildren<HTMLLIElement>) => {
 
 type OptionProps = {
   value: string;
-} & DefaultPropsWithChildren<HTMLLIElement>;
+} & ChildrenProps;
 
 const Option = ({ value, children }: OptionProps) => {
   const context = useContext(SelectContext);

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -86,12 +86,9 @@ const HiddenSelect = forwardRef<HTMLSelectElement, { id: string }>(
 );
 const hiddenStyle = css`
   position: absolute;
+  visibility: hidden;
   height: 0px;
   width: 0px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clippath: inset(50%);
-  whitespace: nowrap;
 `;
 HiddenSelect.displayName = 'HiddenSelect';
 

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -14,8 +14,7 @@ import useSelect from './useSelect';
 
 type SelectProps = {
   id: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setValue?: Dispatch<SetStateAction<any>>;
+  setValue?: Dispatch<SetStateAction<string>>;
   children: ReactNode;
 };
 
@@ -73,7 +72,16 @@ const Option = ({ value, children }: OptionProps) => {
   };
 
   return (
-    <li role="listitem" ref={refCallback} onClick={onSelect}>
+    <li
+      role="listitem"
+      ref={refCallback}
+      onClick={onSelect}
+      css={css`
+        &:hover {
+          cursor: pointer;
+        }
+      `}
+    >
       {children}
     </li>
   );

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,4 @@
-import Dropdown from '@components/Dropdown';
+import Dropdown, { DropdownContext } from '@components/Dropdown';
 import { css } from '@emotion/react';
 import { DefaultPropsWithChildren } from '@util-types/DefaultPropsWithChildren';
 import {
@@ -61,8 +61,19 @@ const Option = ({ value, children }: OptionProps) => {
     registerOption($el, value);
   };
 
+  const dropdownContext = useContext(DropdownContext);
+  if (!dropdownContext) {
+    throw new Error('Select component must have its own Dropdown context');
+  }
+  const { setIsOpen } = dropdownContext;
+
+  const onSelect = () => {
+    selectValue(value);
+    setIsOpen(false);
+  };
+
   return (
-    <li role="listitem" ref={refCallback} onClick={() => selectValue(value)}>
+    <li role="listitem" ref={refCallback} onClick={onSelect}>
       {children}
     </li>
   );

--- a/src/components/Select/useOptions.tsx
+++ b/src/components/Select/useOptions.tsx
@@ -1,0 +1,38 @@
+import { Dispatch, SetStateAction, useRef } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useOptions = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
+  const selectRef = useRef<HTMLSelectElement>(null);
+  const optionRefs = useRef<HTMLLIElement[]>([]);
+
+  const registerOption = ($el: HTMLLIElement, value: string) => {
+    optionRefs.current.push($el);
+
+    if (!selectRef.current) return;
+
+    const option = document.createElement('option');
+    option.id = `${id}-${value}`;
+    option.value = value;
+    selectRef.current.appendChild(option);
+  };
+
+  const selectValue = (value: string) => {
+    if (setValue) setValue(value);
+
+    if (!selectRef.current) return;
+
+    const $target = selectRef.current.querySelector(`#${id}-${value}`);
+    [...selectRef.current.childNodes].forEach(($option) => {
+      if (!($option instanceof HTMLOptionElement)) return;
+      $option.selected = $option === $target;
+    });
+  };
+
+  return {
+    selectRef,
+    registerOption,
+    selectValue,
+  };
+};
+
+export default useOptions;

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -6,12 +6,16 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
   const optionRefs = useRef<HTMLLIElement[]>([]);
 
   const registerOption = ($el: HTMLLIElement, value: string) => {
+    const optionId = `${id}-${value}`;
+
+    if (!selectRef.current || selectRef.current.querySelector(`#${optionId}`)) {
+      return;
+    }
+
     optionRefs.current.push($el);
 
-    if (!selectRef.current) return;
-
     const option = document.createElement('option');
-    option.id = `${id}-${value}`;
+    option.id = optionId;
     option.value = value;
     selectRef.current.appendChild(option);
   };

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction, useRef } from 'react';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const useSelect = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
+const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
   const optionRefs = useRef<HTMLLIElement[]>([]);
 
@@ -26,7 +25,7 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
     if (!selectRef.current) return;
 
     const $target = selectRef.current.querySelector(`#${id}-${value}`);
-    [...selectRef.current.childNodes].forEach(($option) => {
+    selectRef.current.childNodes.forEach(($option) => {
       if (!($option instanceof HTMLOptionElement)) return;
       $option.selected = $option === $target;
     });

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, useRef } from 'react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const useOptions = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
+const useSelect = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
   const optionRefs = useRef<HTMLLIElement[]>([]);
 
@@ -35,4 +35,4 @@ const useOptions = (id: string, setValue?: Dispatch<SetStateAction<any>>) => {
   };
 };
 
-export default useOptions;
+export default useSelect;

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -13,10 +13,10 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
 
     optionRefs.current.push($el);
 
-    const option = document.createElement('option');
-    option.id = optionId;
-    option.value = value;
-    selectRef.current.appendChild(option);
+    const $option = document.createElement('option');
+    $option.id = optionId;
+    $option.value = value;
+    selectRef.current.appendChild($option);
   };
 
   const selectValue = (value: string) => {

--- a/src/styles/flex-box.ts
+++ b/src/styles/flex-box.ts
@@ -16,7 +16,7 @@ export const flexboxStyle = ({
   alignItems = 'center',
   justifyContent = 'center',
   gap = '1rem',
-}: FlexboxStyleProps) => {
+}: FlexboxStyleProps = {}) => {
   return {
     display: 'flex',
     flexDirection,

--- a/src/utils/types/ChildrenProps.ts
+++ b/src/utils/types/ChildrenProps.ts
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export interface ChildrenProps {
+  children: ReactNode;
+}

--- a/src/utils/types/DefaultProps.ts
+++ b/src/utils/types/DefaultProps.ts
@@ -1,6 +1,4 @@
-import { ClassAttributes, HTMLAttributes, ReactNode } from 'react';
+import { ClassAttributes, HTMLAttributes } from 'react';
 
 export type DefaultProps<T extends HTMLElement> = ClassAttributes<T> &
-  HTMLAttributes<T> & {
-    children?: ReactNode;
-  };
+  HTMLAttributes<T>;

--- a/src/utils/types/DefaultPropsWithChildren.ts
+++ b/src/utils/types/DefaultPropsWithChildren.ts
@@ -1,8 +1,5 @@
-import { ReactNode } from 'react';
-
+import { ChildrenProps } from './ChildrenProps';
 import { DefaultProps } from './DefaultProps';
 
-export type DefaultPropsWithChildren<T extends HTMLElement> =
-  DefaultProps<T> & {
-    children: ReactNode;
-  };
+export type DefaultPropsWithChildren<T extends HTMLElement> = DefaultProps<T> &
+  ChildrenProps;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #56 
- 현재 키보드 접근성을 제외한 기본 동작까지만 구현되어 있습니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->

- 형태는 따로 정의하지 않았습니다.
 
  디자인이 포함된 요소들을 아직 구현하지 않아서 스크린샷은 현재 만들어져있는 컴포넌트들로만 구성했어요.

- select 태그와 관련된 로직은 useSelect 훅으로 분리했어요.

  작성된 옵션들을 select 태그 하위의 옵션으로 추가하고, 선택 시 select 여부를 변경해줍니다.

<br />

- 아래와 같은 이유로 린트 규칙을 끈 라인이 있습니다.
  <img width="738" alt="image" src="https://user-images.githubusercontent.com/63814960/226530816-316ec30e-3634-4fd8-9b42-5814902e6e74.png">

  - [피드백](https://github.com/c-h-w-h/cds/pull/65#pullrequestreview-1349785867) 받고 string으로 고정했습니다. 사실 `value ?? 'click here` 이게 쓰고싶어서 `string | null` 했나본데 초기값은 빈 문자열로 넣게 강제했어요. 유사한 동작은 삼항연산자로 작성할 수 있어요. documentation에 적어둘게요.

    ```ts
      <Select.Trigger>
        <Badge outline>{value ? value : 'click here'}</Badge>
      </Select.Trigger>
    ```

- 사실 키보드 접근성을 구현하려면 큰 문제가 하나 있는데, 옵션들이 없어졌다 생겼다(?) 하는 엘레먼트라서 ref 관리가 조금 까다로워요. (optionRefs 크게 수정해야 할듯..해서 여기까지만 리뷰받고 다른 브랜치 파서 작업할게요.)

## 📷 스크린샷


https://user-images.githubusercontent.com/63814960/226530228-5d398806-dddf-4014-8034-47722fb88978.mov


