### PR TITLE
Feat/tabs accessibility : 접근성 속성 및 키보드 이벤트 추가 

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -20,7 +20,7 @@ const DUMMY_STR_3 =
 
 const Template: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List>
+    <Tabs.List label={'기본 Tabs 목록'}>
       <Tabs.Trigger value="1">메인</Tabs.Trigger>
       <Tabs.Trigger value="2">이벤트</Tabs.Trigger>
       <Tabs.Trigger value="3">설정</Tabs.Trigger>
@@ -72,7 +72,7 @@ DefaultValue.args = {
 
 const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List>
+    <Tabs.List label={'아이콘 확인용 Tabs 목록'}>
       <Tabs.Trigger value="1" icon={MdCelebration}>
         축하
       </Tabs.Trigger>
@@ -93,7 +93,7 @@ WithIcons.args = {
 
 const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List>
+    <Tabs.List label={'비활성화 확인용 Tabs 목록'}>
       <Tabs.Trigger value="1" icon={MdCelebration}>
         축하
       </Tabs.Trigger>
@@ -114,7 +114,7 @@ WithDisabled.args = {
 
 const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List>
+    <Tabs.List label={'스크롤이 생기는 Tabs 목록'}>
       <Tabs.Trigger value="1">
         축하하는 탭을 띄우기 위한 트리거입니다.
       </Tabs.Trigger>

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,3 +1,5 @@
+import Container from '@components-layout/Container';
+import { css } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { MdCelebration, MdInfo, MdCheckCircle } from 'react-icons/md';
 
@@ -21,9 +23,9 @@ const DUMMY_STR_3 =
 const Template: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tabs.List label={'기본 Tabs 목록'}>
-      <Tabs.Trigger value="1">메인</Tabs.Trigger>
-      <Tabs.Trigger value="2">이벤트</Tabs.Trigger>
-      <Tabs.Trigger value="3">설정</Tabs.Trigger>
+      <Tabs.Trigger value="1" text="메인" />
+      <Tabs.Trigger value="2" text="이벤트" />
+      <Tabs.Trigger value="3" text="설정" />
     </Tabs.List>
     <Tabs.Panel value="1">
       <span>첫번째 탭</span>
@@ -73,15 +75,9 @@ DefaultValue.args = {
 const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tabs.List label={'아이콘 확인용 Tabs 목록'}>
-      <Tabs.Trigger value="1" icon={MdCelebration}>
-        축하
-      </Tabs.Trigger>
-      <Tabs.Trigger value="2" icon={MdInfo}>
-        정보
-      </Tabs.Trigger>
-      <Tabs.Trigger value="3" icon={MdCheckCircle}>
-        확인
-      </Tabs.Trigger>
+      <Tabs.Trigger value="1" icon={MdCelebration} text="축하" />
+      <Tabs.Trigger value="2" icon={MdInfo} text="정보" />
+      <Tabs.Trigger value="3" icon={MdCheckCircle} text="확인" />
     </Tabs.List>
   </Tabs>
 );
@@ -94,15 +90,9 @@ WithIcons.args = {
 const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tabs.List label={'비활성화 확인용 Tabs 목록'}>
-      <Tabs.Trigger value="1" icon={MdCelebration}>
-        축하
-      </Tabs.Trigger>
-      <Tabs.Trigger value="2" icon={MdInfo} disabled>
-        정보
-      </Tabs.Trigger>
-      <Tabs.Trigger value="3" icon={MdCheckCircle}>
-        확인
-      </Tabs.Trigger>
+      <Tabs.Trigger value="1" icon={MdCelebration} text="축하" />
+      <Tabs.Trigger value="2" icon={MdInfo} text="정보" disabled />
+      <Tabs.Trigger value="3" icon={MdCheckCircle} text="확인" />
     </Tabs.List>
   </Tabs>
 );
@@ -115,21 +105,46 @@ WithDisabled.args = {
 const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tabs.List label={'스크롤이 생기는 Tabs 목록'}>
-      <Tabs.Trigger value="1">
-        축하하는 탭을 띄우기 위한 트리거입니다.
-      </Tabs.Trigger>
-      <Tabs.Trigger value="2">
-        정보를 표시하기 위해서 여기를 클릭하세요.
-      </Tabs.Trigger>
-      <Tabs.Trigger value="3">아무튼 길어지면 스크롤이 생기겠죠?</Tabs.Trigger>
-      <Tabs.Trigger value="4">
-        여기까지 보이시면 너비를 줄여주시겠어요?
-      </Tabs.Trigger>
+      <Tabs.Trigger value="1" text="축하하는 탭을 띄우기 위한 트리거입니다." />
+      <Tabs.Trigger
+        value="2"
+        text="정보를 표시하기 위해서 여기를 클릭하세요."
+      />
+      <Tabs.Trigger value="3" text="아무튼 길어지면 스크롤이 생기겠죠?" />
+      <Tabs.Trigger value="4" text="여기까지 보이시면 너비를 줄여주시겠어요?" />
     </Tabs.List>
   </Tabs>
 );
 
 export const Scrollable = ScrollableTemplate.bind({});
 Scrollable.args = {
+  defaultValue: '1',
+};
+
+const FocusSelectedTemplate: ComponentStory<typeof Tabs> = (args) => (
+  <Container
+    css={css`
+      width: 360px;
+    `}
+  >
+    <Tabs {...args}>
+      <Tabs.List label={''}>
+        <Tabs.Trigger value="1" text="New!!" />
+        <Tabs.Trigger value="2" text="~Hot~" />
+        <Tabs.Trigger value="3" text="상의" />
+        <Tabs.Trigger value="4" text="아우터" />
+        <Tabs.Trigger value="5" text="맨투맨" />
+        <Tabs.Trigger value="6" text="반팔" />
+        <Tabs.Trigger value="7" text="롱슬리브" />
+        <Tabs.Trigger value="8" text="하의" />
+        <Tabs.Trigger value="9" text="반바지" />
+        <Tabs.Trigger value="10" text="슬랙스" />
+      </Tabs.List>
+    </Tabs>
+  </Container>
+);
+
+export const FocusSelected = FocusSelectedTemplate.bind({});
+FocusSelected.args = {
   defaultValue: '1',
 };

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -50,12 +50,14 @@ Default.args = {
 
 export const Rounded = Template.bind({});
 Rounded.args = {
+  label: '둥근 Tabs 목록',
   defaultValue: '1',
   variant: 'rounded',
 };
 
 export const UnderlineFitted = Template.bind({});
 UnderlineFitted.args = {
+  label: '밑줄이 있으면서 너비가 꽉 찬 Tabs 목록',
   defaultValue: '1',
   variant: 'underline',
   isFitted: true,
@@ -63,6 +65,7 @@ UnderlineFitted.args = {
 
 export const RoundedFitted = Template.bind({});
 RoundedFitted.args = {
+  label: '둥글면서 너비가 꽉 찬 Tabs 목록',
   defaultValue: '1',
   variant: 'rounded',
   isFitted: true,
@@ -70,6 +73,7 @@ RoundedFitted.args = {
 
 export const DefaultValue = Template.bind({});
 DefaultValue.args = {
+  label: '기본 값이 설정된 Tabs 목록',
   defaultValue: '3',
 };
 

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -22,7 +22,7 @@ const DUMMY_STR_3 =
 
 const Template: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List label={'기본 Tabs 목록'}>
+    <Tabs.List>
       <Tabs.Trigger value="1" text="메인" />
       <Tabs.Trigger value="2" text="이벤트" />
       <Tabs.Trigger value="3" text="설정" />
@@ -44,6 +44,7 @@ const Template: ComponentStory<typeof Tabs> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
+  label: '기본 Tabs 목록',
   defaultValue: '1',
 };
 
@@ -74,7 +75,7 @@ DefaultValue.args = {
 
 const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List label={'아이콘 확인용 Tabs 목록'}>
+    <Tabs.List>
       <Tabs.Trigger value="1" icon={MdCelebration} text="축하" />
       <Tabs.Trigger value="2" icon={MdInfo} text="정보" />
       <Tabs.Trigger value="3" icon={MdCheckCircle} text="확인" />
@@ -84,12 +85,13 @@ const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
 
 export const WithIcons = WithIconsTemplate.bind({});
 WithIcons.args = {
+  label: '아이콘 확인용 Tabs 목록',
   defaultValue: '1',
 };
 
 const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List label={'비활성화 확인용 Tabs 목록'}>
+    <Tabs.List>
       <Tabs.Trigger value="1" icon={MdCelebration} text="축하" />
       <Tabs.Trigger value="2" icon={MdInfo} text="정보" disabled />
       <Tabs.Trigger value="3" icon={MdCheckCircle} text="확인" />
@@ -99,12 +101,13 @@ const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
 
 export const WithDisabled = WithDisabledTemplate.bind({});
 WithDisabled.args = {
+  label: '비활성화 확인용 Tabs 목록',
   defaultValue: '1',
 };
 
 const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
-    <Tabs.List label={'스크롤이 생기는 Tabs 목록'}>
+    <Tabs.List>
       <Tabs.Trigger value="1" text="축하하는 탭을 띄우기 위한 트리거입니다." />
       <Tabs.Trigger
         value="2"
@@ -118,6 +121,7 @@ const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
 
 export const Scrollable = ScrollableTemplate.bind({});
 Scrollable.args = {
+  label: '스크롤이 생기는 Tabs 목록',
   defaultValue: '1',
 };
 
@@ -128,7 +132,7 @@ const FocusSelectedTemplate: ComponentStory<typeof Tabs> = (args) => (
     `}
   >
     <Tabs {...args}>
-      <Tabs.List label={''}>
+      <Tabs.List>
         <Tabs.Trigger value="1" text="New!!" />
         <Tabs.Trigger value="2" text="~Hot~" />
         <Tabs.Trigger value="3" text="상의" />
@@ -146,5 +150,6 @@ const FocusSelectedTemplate: ComponentStory<typeof Tabs> = (args) => (
 
 export const FocusSelected = FocusSelectedTemplate.bind({});
 FocusSelected.args = {
+  label: '너비가 좁은 Tabs 목록',
   defaultValue: '1',
 };

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -138,7 +138,7 @@ const FocusSelectedTemplate: ComponentStory<typeof Tabs> = (args) => (
     <Tabs {...args}>
       <Tabs.List>
         <Tabs.Trigger value="1" text="New!!" />
-        <Tabs.Trigger value="2" text="~Hot~" />
+        <Tabs.Trigger value="2" text="Hot~~" />
         <Tabs.Trigger value="3" text="상의" />
         <Tabs.Trigger value="4" text="아우터" />
         <Tabs.Trigger value="5" text="맨투맨" />

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -64,7 +64,7 @@ const List = ({ label, children }: TabListProps) => {
   const { color: themeColor } = useTheme();
   const { white, gray100 } = themeColor;
 
-  if (context === null) return null;
+  if (context === null) return <></>;
   return (
     <Container
       role={'tablist'}
@@ -113,7 +113,7 @@ const Trigger = ({
   children,
 }: TabTriggerProps) => {
   const context = useContext(TabsContext);
-  if (context === null) return null;
+  if (context === null) return <></>;
 
   const { color: themeColor } = useTheme();
   const { primary100, gray100, black, white } = themeColor;
@@ -198,7 +198,7 @@ interface TabPanelProps {
 const Panel = ({ value, children }: TabPanelProps) => {
   const context = useContext(TabsContext);
 
-  if (context === null) return null;
+  if (context === null) return <></>;
 
   return (
     <Container

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -19,8 +19,9 @@ import {
 type TabsVariant = 'underline' | 'rounded';
 
 interface TabsContextInterface {
-  isFitted: boolean;
+  label: string;
   variant: TabsVariant;
+  isFitted: boolean;
   selectedIndex: string;
   setSelectedIndex: Dispatch<SetStateAction<string>>;
 }
@@ -28,6 +29,7 @@ interface TabsContextInterface {
 const TabsContext = createContext<TabsContextInterface | null>(null);
 
 interface TabsProps {
+  label: string;
   defaultValue: string;
   children: ReactNode;
   variant?: TabsVariant;
@@ -35,14 +37,21 @@ interface TabsProps {
 }
 
 const Tabs = ({
-  isFitted = false,
-  variant = 'underline',
+  label,
   defaultValue,
   children,
+  variant = 'underline',
+  isFitted = false,
 }: TabsProps) => {
   const [selectedIndex, setSelectedIndex] = useState<string>(defaultValue);
 
-  const providerValue = { isFitted, variant, selectedIndex, setSelectedIndex };
+  const providerValue = {
+    isFitted,
+    variant,
+    label,
+    selectedIndex,
+    setSelectedIndex,
+  };
 
   return (
     <TabsContext.Provider value={providerValue}>
@@ -58,11 +67,10 @@ const Tabs = ({
 };
 
 interface TabListProps {
-  label: string;
   children: ReactNode;
 }
 
-const List = ({ label, children }: TabListProps) => {
+const List = ({ children }: TabListProps) => {
   const context = useContext(TabsContext);
   if (context === null) return <></>;
 
@@ -72,7 +80,7 @@ const List = ({ label, children }: TabListProps) => {
   return (
     <Container
       role={'tablist'}
-      aria-label={label}
+      aria-label={context.label}
       aria-orientation={'horizontal'}
       overflowX="auto"
       css={css`
@@ -183,12 +191,13 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
   return (
     <button
       ref={triggerRef}
-      id={`cds-tabs-trigger-${value}`}
+      id={`${context.label}-trigger-${value}`}
       role={'tab'}
       aria-selected={isActive}
-      aria-controls={`cds-tabs-panel-${value}`}
+      aria-controls={`${context.label}-panel-${value}`}
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
+      aria-disabled={disabled}
       onClick={handleTriggerEvent}
       onKeyDown={handleArrowKeys}
       data-trigger-value={value}
@@ -264,9 +273,9 @@ const Panel = ({ value, children }: TabPanelProps) => {
 
   return (
     <Container
-      id={`cds-tabs-panel-${value}`}
+      id={`${context.label}-panel-${value}`}
       role={'tabpanel'}
-      aria-labelledby={`cds-tabs-trigger-${value}`}
+      aria-labelledby={`${context.label}-trigger-${value}`}
       tabIndex={0}
       css={css`
         padding: 1rem;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -193,13 +193,13 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
     inline: 'start',
   } as const;
 
-  const handleTriggerEvent = () => {
+  const onSelect = () => {
     if (disabled || !triggerRef.current) return;
     setSelectedIndex(value);
     triggerRef.current.scrollIntoView(scrollOptions);
   };
 
-  const handleArrowKeys = (e: KeyboardEvent) => {
+  const onPressArrow = (e: KeyboardEvent) => {
     e.preventDefault();
     const currentTrigger = e.target;
 
@@ -228,8 +228,8 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
       aria-disabled={disabled}
-      onClick={handleTriggerEvent}
-      onKeyDown={handleArrowKeys}
+      onClick={onSelect}
+      onKeyDown={onPressArrow}
       data-trigger-value={value}
       css={css`
         display: flex;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -66,10 +66,10 @@ const Tabs = ({
   );
 };
 
-const useTabs = () => {
+const useTabsContext = () => {
   const context = useContext(TabsContext);
   if (context === null) {
-    throw new Error('useTabs should be used within Tabs');
+    throw new Error('useTabsContext should be used within Tabs');
   }
   return context;
 };
@@ -79,7 +79,7 @@ interface TabListProps {
 }
 
 const List = ({ children }: TabListProps) => {
-  const { label, isFitted } = useTabs();
+  const { label, isFitted } = useTabsContext();
   const { color: themeColor } = useTheme();
   const { white, gray100 } = themeColor;
 
@@ -142,7 +142,7 @@ const findFutureTrigger = (
 };
 
 const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
-  const { label, variant, selectedIndex, setSelectedIndex } = useTabs();
+  const { label, variant, selectedIndex, setSelectedIndex } = useTabsContext();
 
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { color: themeColor } = useTheme();
@@ -289,7 +289,7 @@ interface TabPanelProps {
 }
 
 const Panel = ({ value, children }: TabPanelProps) => {
-  const { label, selectedIndex } = useTabs();
+  const { label, selectedIndex } = useTabsContext();
 
   return (
     <Container

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -147,6 +147,7 @@ const Trigger = ({
       role={'tab'}
       aria-selected={isActive}
       aria-controls={`cds-tabs-panel-${value}`}
+      tabIndex={isActive ? 0 : -1}
       text={children?.toString()}
       disabled={disabled}
       icon={icon}
@@ -204,6 +205,7 @@ const Panel = ({ value, children }: TabPanelProps) => {
       id={`cds-tabs-panel-${value}`}
       role={'tabpanel'}
       aria-labelledby={`cds-tabs-trigger-${value}`}
+      tabIndex={0}
       css={css`
         padding: 1rem;
         display: ${context.selectedIndex === value ? 'block' : 'none'};

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -1,5 +1,5 @@
-import Button from '@components/Button';
-import { IconSource } from '@components/Icon';
+import Icon, { IconSource } from '@components/Icon';
+import Typography from '@components/Typography';
 import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
 import { css, useTheme } from '@emotion/react';
@@ -10,6 +10,7 @@ import {
   ReactNode,
   SetStateAction,
   useContext,
+  useRef,
   useState,
 } from 'react';
 
@@ -101,20 +102,16 @@ const List = ({ label, children }: TabListProps) => {
 
 interface TabTriggerProps {
   value: string;
-  children: ReactNode;
-  disabled?: boolean;
+  text?: string;
   icon?: IconSource;
+  disabled?: boolean;
 }
 
-const Trigger = ({
-  value,
-  disabled = false,
-  icon,
-  children,
-}: TabTriggerProps) => {
+const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
   const context = useContext(TabsContext);
   if (context === null) return <></>;
 
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { color: themeColor } = useTheme();
   const { primary100, gray100, black, white } = themeColor;
   const isActive = context.selectedIndex === value;
@@ -141,19 +138,32 @@ const Trigger = ({
     rounded: roundedStyle,
   };
 
+  const handleTriggerEvent = () => {
+    if (disabled || !triggerRef.current) return;
+    context.setSelectedIndex(value);
+    triggerRef.current.scrollIntoView({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'start',
+    });
+  };
+
   return (
-    <Button
+    <button
+      ref={triggerRef}
       id={`cds-tabs-trigger-${value}`}
       role={'tab'}
       aria-selected={isActive}
       aria-controls={`cds-tabs-panel-${value}`}
       tabIndex={isActive ? 0 : -1}
-      text={children?.toString()}
       disabled={disabled}
-      icon={icon}
-      iconSize={pixelToRem('16px')}
-      onClick={() => !disabled && context.setSelectedIndex(value)}
+      onClick={handleTriggerEvent}
       css={css`
+        display: flex;
+        justify-content: center;
+        padding: 0.75rem;
+        text-decoration: none;
+        scroll-margin: ${pixelToRem('24px')};
         ${triggerStyles[context.variant]}
 
         & > p {
@@ -165,8 +175,17 @@ const Trigger = ({
         }
 
         &:hover {
-          background-color: ${primary100};
+          cursor: pointer;
+          background-color: ${isActive ? white : primary100};
           border-bottom-color: ${primary100};
+
+          & > * {
+            color: ${isActive ? primary100 : white};
+          }
+
+          & > svg {
+            fill: ${isActive ? primary100 : white};
+          }
         }
 
         &:disabled {
@@ -186,7 +205,16 @@ const Trigger = ({
           }
         }
       `}
-    />
+    >
+      {icon && (
+        <Icon
+          source={icon}
+          size={pixelToRem('16px')}
+          color={isActive ? primary100 : black}
+        />
+      )}
+      {text && <Typography variant="body">{text}</Typography>}
+    </button>
   );
 };
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -2,11 +2,13 @@ import Icon, { IconSource } from '@components/Icon';
 import Typography from '@components/Typography';
 import Container from '@components-layout/Container';
 import Flexbox from '@components-layout/Flexbox';
+import { NEXT_KEY, PREV_KEY } from '@constants/key';
 import { css, useTheme } from '@emotion/react';
 import { pixelToRem } from '@utils/pixelToRem';
 import {
   createContext,
   Dispatch,
+  KeyboardEvent,
   ReactNode,
   SetStateAction,
   useContext,
@@ -62,10 +64,11 @@ interface TabListProps {
 
 const List = ({ label, children }: TabListProps) => {
   const context = useContext(TabsContext);
+  if (context === null) return <></>;
+
   const { color: themeColor } = useTheme();
   const { white, gray100 } = themeColor;
 
-  if (context === null) return <></>;
   return (
     <Container
       role={'tablist'}
@@ -148,6 +151,32 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
     });
   };
 
+  const handleArrowKeys = (e: KeyboardEvent) => {
+    e.preventDefault();
+    const currentTrigger = e.target;
+
+    if (!(currentTrigger instanceof HTMLElement)) return;
+
+    let futureTrigger;
+
+    if (NEXT_KEY.includes(e.key)) {
+      futureTrigger = currentTrigger.nextElementSibling as HTMLElement;
+    }
+
+    if (PREV_KEY.includes(e.key)) {
+      futureTrigger = currentTrigger.previousElementSibling as HTMLElement;
+    }
+
+    if (!futureTrigger) return;
+
+    const futureValue = futureTrigger.dataset['triggerValue'];
+
+    if (futureValue === undefined) return;
+
+    futureTrigger.focus();
+    context.setSelectedIndex(futureValue);
+  };
+
   return (
     <button
       ref={triggerRef}
@@ -158,6 +187,8 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
       onClick={handleTriggerEvent}
+      onKeyDown={handleArrowKeys}
+      data-trigger-value={value}
       css={css`
         display: flex;
         justify-content: center;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -139,6 +139,21 @@ const findFutureTrigger = (key: string, currentTrigger: HTMLElement) => {
     futureTrigger = futureTrigger[siblingProp] as HTMLElement;
   }
 
+  if (futureTrigger) return futureTrigger;
+
+  const triggerParent = currentTrigger.parentElement;
+
+  if (triggerParent === null) return;
+
+  futureTrigger =
+    siblingProp === 'nextElementSibling'
+      ? (triggerParent.firstElementChild as HTMLElement)
+      : (triggerParent.lastElementChild as HTMLElement);
+
+  while (futureTrigger.hasAttribute('disabled')) {
+    futureTrigger = futureTrigger[siblingProp] as HTMLElement;
+  }
+
   return futureTrigger;
 };
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -55,10 +55,11 @@ const Tabs = ({
 };
 
 interface TabListProps {
+  label: string;
   children: ReactNode;
 }
 
-const List = ({ children }: TabListProps) => {
+const List = ({ label, children }: TabListProps) => {
   const context = useContext(TabsContext);
   const { color: themeColor } = useTheme();
   const { white, gray100 } = themeColor;
@@ -67,6 +68,7 @@ const List = ({ children }: TabListProps) => {
   return (
     <Container
       role={'tablist'}
+      aria-label={label}
       aria-orientation={'horizontal'}
       overflowX="auto"
       css={css`

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -141,14 +141,16 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
     rounded: roundedStyle,
   };
 
+  const scrollOptions = {
+    behavior: 'smooth',
+    block: 'nearest',
+    inline: 'start',
+  } as const;
+
   const handleTriggerEvent = () => {
     if (disabled || !triggerRef.current) return;
     context.setSelectedIndex(value);
-    triggerRef.current.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-      inline: 'start',
-    });
+    triggerRef.current.scrollIntoView(scrollOptions);
   };
 
   const handleArrowKeys = (e: KeyboardEvent) => {
@@ -174,6 +176,7 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
     if (futureValue === undefined) return;
 
     futureTrigger.focus();
+    futureTrigger.scrollIntoView(scrollOptions);
     context.setSelectedIndex(futureValue);
   };
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -66,21 +66,27 @@ const Tabs = ({
   );
 };
 
+const useTabs = () => {
+  const context = useContext(TabsContext);
+  if (context === null) {
+    throw new Error('useTabs should be used within Tabs');
+  }
+  return context;
+};
+
 interface TabListProps {
   children: ReactNode;
 }
 
 const List = ({ children }: TabListProps) => {
-  const context = useContext(TabsContext);
-  if (context === null) return <></>;
-
+  const { label, isFitted } = useTabs();
   const { color: themeColor } = useTheme();
   const { white, gray100 } = themeColor;
 
   return (
     <Container
       role={'tablist'}
-      aria-label={context.label}
+      aria-label={label}
       aria-orientation={'horizontal'}
       overflowX="auto"
       css={css`
@@ -99,7 +105,7 @@ const List = ({ children }: TabListProps) => {
           border-bottom: 2px solid ${gray100};
 
           & > button {
-            width: ${context.isFitted === true && '100%'};
+            width: ${isFitted === true && '100%'};
             white-space: nowrap;
             background-color: ${white};
           }
@@ -136,16 +142,15 @@ const findFutureTrigger = (
 };
 
 const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
-  const context = useContext(TabsContext);
-  if (context === null) return <></>;
+  const { label, variant, selectedIndex, setSelectedIndex } = useTabs();
 
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { color: themeColor } = useTheme();
   const { primary100, gray100, black, white } = themeColor;
-  const isActive = context.selectedIndex === value;
+  const isActive = selectedIndex === value;
 
   const underlineStyle = {
-    borderColor: `${context.selectedIndex === value ? primary100 : gray100}`,
+    borderColor: `${selectedIndex === value ? primary100 : gray100}`,
     borderRadius: 0,
     borderBottomWidth: '2px',
     borderBottomStyle: 'solid',
@@ -153,7 +158,7 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
   } as const;
 
   const roundedStyle = {
-    border: `${context.selectedIndex === value && `2px ${gray100} solid`}`,
+    border: `${selectedIndex === value && `2px ${gray100} solid`}`,
     borderRadius: '10px',
     borderBottomLeftRadius: 0,
     borderBottomRightRadius: 0,
@@ -174,7 +179,7 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
 
   const handleTriggerEvent = () => {
     if (disabled || !triggerRef.current) return;
-    context.setSelectedIndex(value);
+    setSelectedIndex(value);
     triggerRef.current.scrollIntoView(scrollOptions);
   };
 
@@ -202,16 +207,16 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
 
     futureTrigger.focus();
     futureTrigger.scrollIntoView(scrollOptions);
-    context.setSelectedIndex(futureValue);
+    setSelectedIndex(futureValue);
   };
 
   return (
     <button
       ref={triggerRef}
-      id={`${context.label}-trigger-${value}`}
+      id={`${label}-trigger-${value}`}
       role={'tab'}
       aria-selected={isActive}
-      aria-controls={`${context.label}-panel-${value}`}
+      aria-controls={`${label}-panel-${value}`}
       tabIndex={isActive ? 0 : -1}
       disabled={disabled}
       aria-disabled={disabled}
@@ -224,7 +229,7 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
         padding: 0.75rem;
         text-decoration: none;
         scroll-margin: ${pixelToRem('24px')};
-        ${triggerStyles[context.variant]}
+        ${triggerStyles[variant]}
 
         & > p {
           color: ${isActive ? primary100 : black};
@@ -284,19 +289,17 @@ interface TabPanelProps {
 }
 
 const Panel = ({ value, children }: TabPanelProps) => {
-  const context = useContext(TabsContext);
-
-  if (context === null) return <></>;
+  const { label, selectedIndex } = useTabs();
 
   return (
     <Container
-      id={`${context.label}-panel-${value}`}
+      id={`${label}-panel-${value}`}
       role={'tabpanel'}
-      aria-labelledby={`${context.label}-trigger-${value}`}
+      aria-labelledby={`${label}-trigger-${value}`}
       tabIndex={0}
       css={css`
         padding: 1rem;
-        display: ${context.selectedIndex === value ? 'block' : 'none'};
+        display: ${selectedIndex === value ? 'block' : 'none'};
       `}
     >
       {children}

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -118,6 +118,23 @@ interface TabTriggerProps {
   disabled?: boolean;
 }
 
+type KeyDirection = 'NEXT' | 'PREV';
+
+const findFutureTrigger = (
+  direction: KeyDirection,
+  currentTrigger: HTMLElement,
+) => {
+  const siblingProp =
+    direction === 'NEXT' ? 'nextElementSibling' : 'previousElementSibling';
+  let futureTrigger = currentTrigger[siblingProp] as HTMLElement;
+
+  while (futureTrigger && futureTrigger.hasAttribute('disabled')) {
+    futureTrigger = futureTrigger[siblingProp] as HTMLElement;
+  }
+
+  return futureTrigger;
+};
+
 const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
   const context = useContext(TabsContext);
   if (context === null) return <></>;
@@ -170,11 +187,11 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
     let futureTrigger;
 
     if (NEXT_KEY.includes(e.key)) {
-      futureTrigger = currentTrigger.nextElementSibling as HTMLElement;
+      futureTrigger = findFutureTrigger('NEXT', currentTrigger);
     }
 
     if (PREV_KEY.includes(e.key)) {
-      futureTrigger = currentTrigger.previousElementSibling as HTMLElement;
+      futureTrigger = findFutureTrigger('PREV', currentTrigger);
     }
 
     if (!futureTrigger) return;

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -66,6 +66,8 @@ const List = ({ children }: TabListProps) => {
   if (context === null) return null;
   return (
     <Container
+      role={'tablist'}
+      aria-orientation={'horizontal'}
       overflowX="auto"
       css={css`
         -ms-overflow-style: none;
@@ -139,6 +141,10 @@ const Trigger = ({
 
   return (
     <Button
+      id={`cds-tabs-trigger-${value}`}
+      role={'tab'}
+      aria-selected={isActive}
+      aria-controls={`cds-tabs-panel-${value}`}
       text={children?.toString()}
       disabled={disabled}
       icon={icon}
@@ -193,6 +199,9 @@ const Panel = ({ value, children }: TabPanelProps) => {
 
   return (
     <Container
+      id={`cds-tabs-panel-${value}`}
+      role={'tabpanel'}
+      aria-labelledby={`cds-tabs-trigger-${value}`}
       css={css`
         padding: 1rem;
         display: ${context.selectedIndex === value ? 'block' : 'none'};

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -124,14 +124,15 @@ interface TabTriggerProps {
   disabled?: boolean;
 }
 
-type KeyDirection = 'NEXT' | 'PREV';
+const findFutureTrigger = (key: string, currentTrigger: HTMLElement) => {
+  const siblingProp = (function (key) {
+    if (NEXT_KEY.includes(key)) return 'nextElementSibling';
+    if (PREV_KEY.includes(key)) return 'previousElementSibling';
+    return null;
+  })(key);
 
-const findFutureTrigger = (
-  direction: KeyDirection,
-  currentTrigger: HTMLElement,
-) => {
-  const siblingProp =
-    direction === 'NEXT' ? 'nextElementSibling' : 'previousElementSibling';
+  if (siblingProp === null) return;
+
   let futureTrigger = currentTrigger[siblingProp] as HTMLElement;
 
   while (futureTrigger && futureTrigger.hasAttribute('disabled')) {
@@ -189,15 +190,7 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
 
     if (!(currentTrigger instanceof HTMLElement)) return;
 
-    let futureTrigger;
-
-    if (NEXT_KEY.includes(e.key)) {
-      futureTrigger = findFutureTrigger('NEXT', currentTrigger);
-    }
-
-    if (PREV_KEY.includes(e.key)) {
-      futureTrigger = findFutureTrigger('PREV', currentTrigger);
-    }
+    const futureTrigger = findFutureTrigger(e.key, currentTrigger);
 
     if (!futureTrigger) return;
 

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -79,9 +79,9 @@ interface TabListProps {
 }
 
 const List = ({ children }: TabListProps) => {
-  const { label, isFitted } = useTabsContext();
+  const { label } = useTabsContext();
   const { color: themeColor } = useTheme();
-  const { white, gray100 } = themeColor;
+  const { gray100 } = themeColor;
 
   return (
     <Container
@@ -103,12 +103,6 @@ const List = ({ children }: TabListProps) => {
           gap: 0;
           width: 100%;
           border-bottom: 2px solid ${gray100};
-
-          & > button {
-            width: ${isFitted === true && '100%'};
-            white-space: nowrap;
-            background-color: ${white};
-          }
         `}
       >
         {children}
@@ -158,7 +152,8 @@ const findFutureTrigger = (key: string, currentTrigger: HTMLElement) => {
 };
 
 const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
-  const { label, variant, selectedIndex, setSelectedIndex } = useTabsContext();
+  const { label, variant, isFitted, selectedIndex, setSelectedIndex } =
+    useTabsContext();
 
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { color: themeColor } = useTheme();
@@ -236,6 +231,9 @@ const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
         justify-content: center;
         padding: 0.75rem;
         text-decoration: none;
+        white-space: nowrap;
+        width: ${isFitted === true && '100%'};
+        background-color: ${white};
         scroll-margin: ${pixelToRem('24px')};
         ${triggerStyles[variant]}
 

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -1,0 +1,3 @@
+export const NEXT_KEY = ['37', '38', 'ArrowUp', 'ArrowRight'];
+
+export const PREV_KEY = ['39', '40', 'ArrowLeft', 'ArrowDown'];


### PR DESCRIPTION
## 🤠 개요

- #66 
- 접근성 속성을 추가하고 키보드 이벤트를 추가합니다. 


## 💫 설명

- MDN에서 정의한 탭의 role 속성을 Trigger에 추가했습니다. ( role="tab")

- 추가로 tabList와 tabPanel 역할도 List와 Panel에 추가했습니다. 

- Trigger가 Focus된 상태에서 Tab을 누르면 Panel로 이동해야 하기 때문에 선택된 Trigger의 tabIndex는 0으로, 
  그렇지 않으면 -1로 합니다.

- 다음의 aria-* 속성을 추가했습니다. 

  - aria-label : 어떤 탭 목록을 나타내는지 명시합니다.

    - 이를 위해서 List에서 label 속성을 props로 전달받습니다.  

  - aria-orientation : 탭으 방향을 명시합니다. 수평 탭만 지원하고 있기 때문에  horizontal 을 고정값으로 사용합니다. 

  - aria-selected : 선택된 Trigger 에서 true 값을 가집니다. 

  - aria-controls : Trigger가 제어하는 Panel의 id 값을 명시합니다. (value 로 Panel의 id를 설정했습니다.)

  - aria-labelledby : Panel을 제어하고 있는 Trigger의 id 값을 명시합니다. (value 로 Trigger의 id를 설정했습니다.)
 
- 키보드 방향키로 탭을 이동할 수 있게 했습니다. 

  -  constants/key.ts에서 이동방향이 같은 방향키들의 key 코드와 key 이름을 배열에 정의했습니다. 

  - Trigger가 Focus된 상태에서 다음 Trigger 혹은 이전 Trigger가 존재할 경우 해당 요소로 이동합니다. 

    - 이 때, selectedIndex 값도 변경하여 Panel 도 변경됩니다. 

- ScrollIntoView를 적용하여 이동한 Trigger가 화면에 표시되도록 합니다. 

  - ref 를 적용해야 해서 Button 컴포넌트를 사용하지 않고 button 태그를 사용합니다. 

  - 스크롤 이동을 확인하기 위한 스토리를 추가했습니다. 

---

+추가)

context에 대해서 계속 null 체크해주는게 불편해서 컨텍스트에 있는 값을 사용하는 훅을 선언했어요

```
const useTabs = () => {
  const context = useContext(TabsContext);
  if (context === null) {
    throw new Error('useTabs should be used within Tabs');
  }
  return context;
};
```
early return 할 때 어제는 fragment 를 반환하자는 입장이었는데, 저렇게 에러하는 레퍼런스를 봐버려서 일단 throw error 하도록 했습니다. 

```
const List = ({ children }: TabListProps) => {
  const { label, isFitted } = useTabs();
  // early return 필요 없음 
 // (생략)
```
실제 Compound 요소 안에서 사용하면 위와 같이 사용할 수 있어요.
이제 매번 early return 으로 처리하는 수고를 덜 수 있을 것 같아요.

참고했던 블로그 링크 남길게요. 읽어보시면 저보다 더 잘 활용하실 수 있을거라 믿어요~~ 

[다른 사람들이 안 알려주는 리액트에서 Context API 잘 쓰는 방법](https://velog.io/@velopert/react-context-tutorial#context-%EC%97%90%EC%84%9C-%EC%83%81%ED%83%9C-%EA%B4%80%EB%A6%AC%EA%B0%80-%ED%95%84%EC%9A%94%ED%95%9C-%EA%B2%BD%EC%9A%B0)

---

+추가)

Trigger 가 맨앞에 Focus된 상황에서는 맨끝으로, 맨끝에 Focus된 상황에서는 맨앞으로 이동해야 한다는 점을 알게 되어서 
함수에 동작을 추가했어요.

- 끝에서 끝으로 Focus

https://user-images.githubusercontent.com/31645195/227310577-15ecf90a-49a2-4387-ae1e-b9c196bce88a.mov

<br />

- Disabled 일 경우도 피해갑니다. (이 부분은 Disabled 를 커스텀하시면서 확인해보세요)

https://user-images.githubusercontent.com/31645195/227310569-7a2f2d24-4ecc-4ead-92e4-ca4454dd8f4f.mov
