### PR TITLE
Refactor/dropdown: Dropdown 컴포넌트 리팩토링

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -31,9 +31,9 @@ const Template: ComponentStory<typeof Dropdown> = (args) => (
     `}
   >
     <Dropdown {...args}>
-      <Dropdown.Trigger
-        Element={<Button text="팀원 목록" icon={MdPeople} variant="light" />}
-      />
+      <Dropdown.Trigger>
+        <Button text="팀원 목록" icon={MdPeople} variant="light" />
+      </Dropdown.Trigger>
       <Dropdown.Menu>
         <List
           css={css`

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -58,22 +58,22 @@ Default.args = {
   dropdownLabel: 'Default dropdown',
 };
 
-export const DirectonTop = Template.bind({});
-DirectonTop.args = {
+export const DirectionTop = Template.bind({});
+DirectionTop.args = {
   id: 'dropdown2',
   dropdownLabel: 'Default dropdown',
   direction: 'top',
 };
 
-export const DirectonLeft = Template.bind({});
-DirectonLeft.args = {
+export const DirectionLeft = Template.bind({});
+DirectionLeft.args = {
   id: 'dropdown3',
   dropdownLabel: 'Default dropdown',
   direction: 'left',
 };
 
-export const DirectonRight = Template.bind({});
-DirectonRight.args = {
+export const DirectionRight = Template.bind({});
+DirectionRight.args = {
   id: 'dropdown4',
   dropdownLabel: 'Default dropdown',
   direction: 'right',

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -31,9 +31,9 @@ const Template: ComponentStory<typeof Dropdown> = (args) => (
     `}
   >
     <Dropdown {...args}>
-      <Dropdown.Trigger>
-        <Button text="팀원 목록" icon={MdPeople} variant="light" />
-      </Dropdown.Trigger>
+      <Dropdown.Trigger
+        Element={<Button text="팀원 목록" icon={MdPeople} variant="light" />}
+      />
       <Dropdown.Menu>
         <List
           css={css`

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -54,34 +54,29 @@ const Template: ComponentStory<typeof Dropdown> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  id: 'dropdown1',
-  dropdownLabel: 'Default dropdown',
+  label: 'dropdown1',
 };
 
 export const DirectionTop = Template.bind({});
 DirectionTop.args = {
-  id: 'dropdown2',
-  dropdownLabel: 'Default dropdown',
+  label: 'dropdown2',
   direction: 'top',
 };
 
 export const DirectionLeft = Template.bind({});
 DirectionLeft.args = {
-  id: 'dropdown3',
-  dropdownLabel: 'Default dropdown',
+  label: 'dropdown3',
   direction: 'left',
 };
 
 export const DirectionRight = Template.bind({});
 DirectionRight.args = {
-  id: 'dropdown4',
-  dropdownLabel: 'Default dropdown',
+  label: 'dropdown4',
   direction: 'right',
 };
 
 export const CollapseOnBlur = Template.bind({});
 CollapseOnBlur.args = {
-  id: 'dropdown5',
-  dropdownLabel: 'Default dropdown',
+  label: 'dropdown5',
   collapseOnBlur: true,
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -103,8 +103,8 @@ const Trigger = ({ children }: { children: ReactElement }) => {
   };
 
   const onKeyDown: KeyboardEventHandler = (e: KeyboardEvent) => {
-    e.preventDefault();
     if (e.key === ' ' || e.key === 'Enter') {
+      e.preventDefault();
       setIsOpen((prev) => !prev);
     }
   };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -78,7 +78,7 @@ const Dropdown = ({
   );
 };
 
-const Trigger = ({ Element }: { Element: ReactElement }) => {
+const Trigger = ({ children }: { children: ReactElement }) => {
   const context = useContext(DropdownContext);
 
   if (!context) return <></>;
@@ -94,7 +94,7 @@ const Trigger = ({ Element }: { Element: ReactElement }) => {
     });
   }, []);
 
-  return cloneElement(Element, {
+  return cloneElement(children, {
     onClick: (e: ReactMouseEvent) => {
       e.stopPropagation();
       setIsOpen(!isOpen);

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -16,8 +16,7 @@ import {
 } from 'react';
 
 type DropdownProps = {
-  id: string;
-  dropdownLabel: string;
+  label: string;
   collapseOnBlur: boolean;
   direction?: 'left' | 'right' | 'top' | 'bottom';
 } & ChildrenProps;
@@ -26,8 +25,7 @@ interface DropdownContextInterface {
   isOpen: boolean;
   setIsOpen: Dispatch<SetStateAction<boolean>>;
   collapseOnBlur: boolean;
-  dropdownLabel: string;
-  id: string;
+  label: string;
   direction: 'left' | 'right' | 'top' | 'bottom';
   triggerSize: {
     width: number;
@@ -43,8 +41,7 @@ interface DropdownContextInterface {
 const DropdownContext = createContext<DropdownContextInterface | null>(null);
 
 const Dropdown = ({
-  id = '',
-  dropdownLabel = '',
+  label,
   collapseOnBlur = false,
   direction = 'bottom',
   children,
@@ -59,8 +56,7 @@ const Dropdown = ({
     isOpen,
     setIsOpen,
     collapseOnBlur,
-    dropdownLabel,
-    id,
+    label,
     direction,
     triggerSize,
     setTriggerSize,
@@ -84,14 +80,13 @@ const Dropdown = ({
 
 const Trigger = ({ Element }: { Element: ReactElement }) => {
   const context = useContext(DropdownContext);
-  const triggerRef = useRef<HTMLDivElement | null>(null);
 
   if (!context) return <></>;
 
-  const { isOpen, setIsOpen, dropdownLabel, id, setTriggerSize } = context;
+  const { isOpen, setIsOpen, label, setTriggerSize } = context;
 
   useEffect(() => {
-    const $trigger = document.getElementById(id);
+    const $trigger = document.getElementById(`${label}-Trigger`);
     if (!$trigger) return;
     setTriggerSize({
       width: $trigger.offsetWidth,
@@ -106,9 +101,9 @@ const Trigger = ({ Element }: { Element: ReactElement }) => {
     },
     'aria-expanded': isOpen,
     'aria-haspopup': 'true',
-    'aria-label': dropdownLabel,
-    id: id,
-    ref: triggerRef,
+    'aria-label': `Dropdown Trigger of ${label}`,
+    'aria-controls': `${label}-Dropdown`,
+    id: `${label}-Trigger`,
   });
 };
 
@@ -118,7 +113,7 @@ const Menu = ({ children }: ChildrenProps) => {
 
   if (!context) return <></>;
 
-  const { isOpen, setIsOpen, collapseOnBlur, id, direction, triggerSize } =
+  const { isOpen, setIsOpen, collapseOnBlur, label, direction, triggerSize } =
     context;
 
   const toggleEventHandler = (e: MouseEvent) => {
@@ -147,7 +142,8 @@ const Menu = ({ children }: ChildrenProps) => {
   return (
     <MenuWrapper
       ref={menuRef}
-      aria-labelledby={id}
+      aria-labelledby={`${label}-Trigger`}
+      id={`${label}-Dropdown`}
       direction={direction ?? 'bottom'}
       triggerSize={triggerSize ?? { width: 0, height: 0 }}
     >

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -20,7 +20,7 @@ import {
 
 type DropdownProps = {
   label: string;
-  collapseOnBlur: boolean;
+  collapseOnBlur?: boolean;
   direction?: 'left' | 'right' | 'top' | 'bottom';
 } & ChildrenProps;
 

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -6,6 +6,8 @@ import {
   cloneElement,
   createContext,
   Dispatch,
+  KeyboardEvent,
+  KeyboardEventHandler,
   MouseEvent as ReactMouseEvent,
   MouseEventHandler,
   ReactElement,
@@ -100,13 +102,21 @@ const Trigger = ({ children }: { children: ReactElement }) => {
     setIsOpen(!isOpen);
   };
 
+  const onKeyDown: KeyboardEventHandler = (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (e.key === ' ' || e.key === 'Enter') {
+      setIsOpen((prev) => !prev);
+    }
+  };
+
   return cloneElement(children, {
     onClick,
+    onKeyDown,
     'aria-expanded': isOpen,
     'aria-haspopup': 'true',
     'aria-label': `Dropdown Trigger of ${label}`,
     'aria-controls': `${label}-Dropdown`,
-    tabindex: 0,
+    tabIndex: 0,
     id: `${label}-Trigger`,
   });
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -3,9 +3,11 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ChildrenProps } from '@util-types/ChildrenProps';
 import {
+  cloneElement,
   createContext,
   Dispatch,
   MouseEvent as ReactMouseEvent,
+  ReactElement,
   SetStateAction,
   useContext,
   useEffect,
@@ -80,7 +82,7 @@ const Dropdown = ({
   );
 };
 
-const Trigger = ({ children }: ChildrenProps) => {
+const Trigger = ({ Element }: { Element: ReactElement }) => {
   const context = useContext(DropdownContext);
   const triggerRef = useRef<HTMLDivElement | null>(null);
 
@@ -89,28 +91,25 @@ const Trigger = ({ children }: ChildrenProps) => {
   const { isOpen, setIsOpen, dropdownLabel, id, setTriggerSize } = context;
 
   useEffect(() => {
-    if (!triggerRef.current || !setTriggerSize) return;
+    const $trigger = document.getElementById(id);
+    if (!$trigger) return;
     setTriggerSize({
-      width: triggerRef.current.offsetWidth,
-      height: triggerRef.current.offsetHeight,
+      width: $trigger.offsetWidth,
+      height: $trigger.offsetHeight,
     });
-  }, [triggerRef.current]);
+  }, []);
 
-  return (
-    <div
-      onClick={(e: ReactMouseEvent) => {
-        e.stopPropagation();
-        setIsOpen(!isOpen);
-      }}
-      aria-expanded={isOpen}
-      aria-haspopup="true"
-      aria-label={dropdownLabel}
-      id={id}
-      ref={triggerRef}
-    >
-      {children}
-    </div>
-  );
+  return cloneElement(Element, {
+    onClick: (e: ReactMouseEvent) => {
+      e.stopPropagation();
+      setIsOpen(!isOpen);
+    },
+    'aria-expanded': isOpen,
+    'aria-haspopup': 'true',
+    'aria-label': dropdownLabel,
+    id: id,
+    ref: triggerRef,
+  });
 };
 
 const Menu = ({ children }: ChildrenProps) => {

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -7,6 +7,7 @@ import {
   createContext,
   Dispatch,
   MouseEvent as ReactMouseEvent,
+  MouseEventHandler,
   ReactElement,
   SetStateAction,
   useContext,
@@ -94,15 +95,18 @@ const Trigger = ({ children }: { children: ReactElement }) => {
     });
   }, []);
 
+  const onClick: MouseEventHandler = (e: ReactMouseEvent) => {
+    e.stopPropagation();
+    setIsOpen(!isOpen);
+  };
+
   return cloneElement(children, {
-    onClick: (e: ReactMouseEvent) => {
-      e.stopPropagation();
-      setIsOpen(!isOpen);
-    },
+    onClick,
     'aria-expanded': isOpen,
     'aria-haspopup': 'true',
     'aria-label': `Dropdown Trigger of ${label}`,
     'aria-controls': `${label}-Dropdown`,
+    tabindex: 0,
     id: `${label}-Trigger`,
   });
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -146,8 +146,11 @@ const Menu = ({ children }: ChildrenProps) => {
       id={`${label}-Dropdown`}
       direction={direction ?? 'bottom'}
       triggerSize={triggerSize ?? { width: 0, height: 0 }}
+      css={css`
+        display: ${isOpen ? 'flex' : 'none'};
+      `}
     >
-      {isOpen && children}
+      {children}
     </MenuWrapper>
   );
 };


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #68 
- 이슈의 마지막 댓글에서 논의했던 대로, 이제 더 이상 Trigger Element를 실제 onClick Handler가 붙은 div로 감싸는 게 아니라 Element에 직접 바인딩해요. 접근성 태그도 마찬가지에요.
- Dropdown.List의 내용을 조건부 렌더링하지 않고 `display:none;`으로 숨겨요.
- 기존의 일관성 없던 id props를 필수 props `label`로 변경하고, 이를 기반으로 접근성 태그와 id를 붙이도록 했어요.

## 💫 설명

<!--

- 현재 Pr 설명

-->

- `display:none`은 접근성 트리에서도 제거되기 때문에 따로 aria-hidden은 붙이지 않았어요.
- Context만을 반환하는 Dropdown에 id props가 있는게 혼동을 일으킨다고 생각해서 label로 이름을 변경했어요.

  - 이제 Trigger와 List 둘 다 label을 기반으로 id를 생성, 접근성 태그를 붙여요.

<br/>

```
<Dropdown.Trigger> // Trigger div
  <button/> // 껍데기 element
</Dropdown.Trigger>
```
- 이슈에 남긴 토론이 길어서 간략하게 설명하자면, Trigger에는 button처럼 _상호작용 가능한_ 요소가 올텐데 이를 실제 트리거 역할을 하는 div로 감싸는 것이 잘못 되었다 생각했어요.
  - 이는 키보드 접근성에서도 실제 Trigger div, 껍데기 element 두 개의 `tabIndex`가 생기는 부작용이 있어요.
  
  - 또 focus를 Trigger div에만 한정시켜야 하는 문제가 있어 css 스타일링에도 어려움이 있어요.

    - 예) Dropdown.Trigger 요소에 focus가 가기 때문에 Select Trigger의 정의된 형태에 :focus 스타일을 적용할 수 없었어요.
  
  - 그 외에 aria 태그가 껍데기 element가 아닌 그 위의 Trigger div에 붙어 있는 구조가 어색하다고 생각했어요.

<br/>

- 결론: cloneElement가 Legacy API로 분류되어 있기는 하지만, Dropdown 담당자와 사용자 @se030의 논의 결과 현재 상황에서 최선의 선택이라고 생각했어요. 아직 deprecated 된 것도 아니고 props를 추가할 수 있는 대안이 없기 때문이에요. 더 좋은 방법이 생각나면 알려주세요!

## 📷 스크린샷 (Optional)
