### PR TITLE
Refactor/toast: Toast 커스텀 훅 정의 및 duration Props 추가 

### DIFF
--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -24,6 +24,61 @@ const Template: ComponentStory<typeof Toast> = (args) => {
   return <Toast {...args} {...toastProps} />;
 };
 
+export const Alert = Template.bind({});
+Alert.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'alert',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const Info = Template.bind({});
+Info.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'info',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'success',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'warning',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'error',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const WithTitle = Template.bind({});
+WithTitle.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  title: DUMMY_TITLE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const LongMessage = Template.bind({});
+LongMessage.args = {
+  message: DUMMY_LONG_MESSAGE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
 export const TopLeft = Template.bind({});
 TopLeft.args = {
   message: DUMMY_SHORT_MESSAGE,
@@ -64,53 +119,6 @@ BottomRight.args = {
   message: DUMMY_SHORT_MESSAGE,
   vertical: 'bottom',
   horizontal: 'right',
-};
-
-export const WithTitle = Template.bind({});
-WithTitle.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  title: DUMMY_TITLE,
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const LongMessage = Template.bind({});
-LongMessage.args = {
-  message: DUMMY_LONG_MESSAGE,
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Info = Template.bind({});
-Info.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'info',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Success = Template.bind({});
-Success.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'success',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Warning = Template.bind({});
-Warning.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'warning',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'error',
-  vertical: 'top',
-  horizontal: 'left',
 };
 
 const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -18,9 +18,11 @@ const DUMMY_SHORT_MESSAGE = '토스트 메세지입니다.';
 const DUMMY_LONG_MESSAGE =
   '긴 토스트 메세지입니다. 현재 토스트 메세지의 최대 길이는 10vw로 설정되어 있습니다.';
 
-const Template: ComponentStory<typeof Toast> = (args) => (
-  <Toast {...args} open={true} />
-);
+const Template: ComponentStory<typeof Toast> = (args) => {
+  const { open, onCloseToast } = useToast(true);
+
+  return <Toast {...args} open={open} onClose={onCloseToast} />;
+};
 
 export const TopLeft = Template.bind({});
 TopLeft.args = {
@@ -112,12 +114,12 @@ Error.args = {
 };
 
 const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
-  const { open, handleOpen, handleClose } = useToast();
+  const { open, onOpenToast, onCloseToast } = useToast();
 
   return (
     <>
-      <Button text="열려라 참깨" onClick={handleOpen} />
-      <Toast {...args} open={open} onClose={handleClose} />
+      <Button text="열려라 참깨" onClick={onOpenToast} />
+      <Toast {...args} open={open} onClose={onCloseToast} />
     </>
   );
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -19,9 +19,9 @@ const DUMMY_LONG_MESSAGE =
   '긴 토스트 메세지입니다. 현재 토스트 메세지의 최대 길이는 10vw로 설정되어 있습니다.';
 
 const Template: ComponentStory<typeof Toast> = (args) => {
-  const { open, onCloseToast } = useToast(true);
+  const { toastProps } = useToast(true);
 
-  return <Toast {...args} open={open} onClose={onCloseToast} />;
+  return <Toast {...args} {...toastProps} />;
 };
 
 export const TopLeft = Template.bind({});
@@ -114,12 +114,12 @@ Error.args = {
 };
 
 const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
-  const { open, onOpenToast, onCloseToast } = useToast();
+  const { openToast, toastProps } = useToast();
 
   return (
     <>
-      <Button text="열려라 참깨" onClick={onOpenToast} />
-      <Toast {...args} open={open} onClose={onCloseToast} />
+      <Button text="열려라 참깨" onClick={openToast} />
+      <Toast {...args} {...toastProps} />
     </>
   );
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -111,7 +111,7 @@ Error.args = {
   horizontal: 'left',
 };
 
-const OpenToastTemplate: ComponentStory<typeof Toast> = (args) => {
+const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
   const { open, handleOpen, handleClose } = useToast();
 
   return (
@@ -122,10 +122,19 @@ const OpenToastTemplate: ComponentStory<typeof Toast> = (args) => {
   );
 };
 
-export const WithToastHook = OpenToastTemplate.bind({});
+export const WithToastHook = ToastHookTemplate.bind({});
 WithToastHook.args = {
-  message: DUMMY_SHORT_MESSAGE,
+  message: 'X 버튼을 누르면 사라져요.',
   kind: 'info',
   vertical: 'top',
   horizontal: 'center',
+};
+
+export const CustomDuration = ToastHookTemplate.bind({});
+CustomDuration.args = {
+  message: '10초동안 보입니다.',
+  kind: 'info',
+  vertical: 'top',
+  horizontal: 'center',
+  duration: 10000,
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -117,7 +117,7 @@ const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
   return (
     <>
       <Button text="열려라 참깨" onClick={handleOpen} />
-      <Toast {...args} open={open} onChangeOpen={handleClose} />
+      <Toast {...args} open={open} onClose={handleClose} />
     </>
   );
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,7 @@
+import Button from '@components/Button';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import useToast from './useToast';
 
 import Toast from '.';
 
@@ -15,7 +18,9 @@ const DUMMY_SHORT_MESSAGE = '토스트 메세지입니다.';
 const DUMMY_LONG_MESSAGE =
   '긴 토스트 메세지입니다. 현재 토스트 메세지의 최대 길이는 10vw로 설정되어 있습니다.';
 
-const Template: ComponentStory<typeof Toast> = (args) => <Toast {...args} />;
+const Template: ComponentStory<typeof Toast> = (args) => (
+  <Toast {...args} open={true} />
+);
 
 export const TopLeft = Template.bind({});
 TopLeft.args = {
@@ -104,4 +109,23 @@ Error.args = {
   kind: 'error',
   vertical: 'top',
   horizontal: 'left',
+};
+
+const OpenToastTemplate: ComponentStory<typeof Toast> = (args) => {
+  const { open, handleOpen, handleClose } = useToast();
+
+  return (
+    <>
+      <Button text="열려라 참깨" onClick={handleOpen} />
+      <Toast {...args} open={open} onChangeOpen={handleClose} />
+    </>
+  );
+};
+
+export const WithToastHook = OpenToastTemplate.bind({});
+WithToastHook.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'info',
+  vertical: 'top',
+  horizontal: 'center',
 };

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -40,7 +40,7 @@ const Toast = ({
   vertical,
   horizontal,
   duration = 3000,
-  open = false,
+  open,
   onClose,
 }: ToastProps) => {
   const { color: themeColor } = theme;

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,6 +1,7 @@
 import { theme } from '@components/@common/CdsProvider/theme';
 import Flexbox from '@components/@layout/Flexbox';
 import Typography from '@components/Typography';
+import Portal from '@components-common/Portal';
 import {
   ToastKind,
   VerticalVariant,
@@ -23,54 +24,68 @@ export interface ToastProps extends DefaultProps<HTMLDivElement> {
   message: string;
   vertical: VerticalVariant;
   horizontal: HorizontalVariant;
+  open: boolean;
+  onChangeOpen: () => void;
 }
 
 const startWithCapitalLetter = (str: string) =>
   str[0].toUpperCase() + str.substring(1);
 
-const Toast = ({ kind, title, message, vertical, horizontal }: ToastProps) => {
+const Toast = ({
+  kind,
+  title,
+  message,
+  vertical,
+  horizontal,
+  open = false,
+  onChangeOpen,
+}: ToastProps) => {
   const { color: themeColor } = theme;
   const mainColor = kind ? themeColor[kind] : '';
 
   return (
-    <Flexbox
-      css={[
-        css`
-          position: absolute;
-          padding: 1rem;
-          border: 2px solid ${mainColor};
-          border-radius: 16px;
-          opacity: 0;
-          animation: ${fadeIn} 0.01s 1s linear forwards;
+    <Portal>
+      {open && (
+        <Flexbox
+          css={[
+            css`
+              position: absolute;
+              padding: 1rem;
+              border: 2px solid ${mainColor};
+              border-radius: 16px;
+              opacity: 0;
+              animation: ${fadeIn} 0.01s 0.1s linear forwards;
 
-          & * {
-            animation: ${bounce(vertical)} 0.6s 1s
-              cubic-bezier(0.34, 1.72, 0.58, 0.85) forwards;
-          }
-        `,
-        V_POSITION_MAP[vertical],
-        H_POSITION_MAP[horizontal],
-      ]}
-    >
-      <ToastIcon kind={kind} size={MAIN_ICON_SIZE} color={mainColor} />
-      <Flexbox
-        flexDirection="column"
-        alignItems={'flex-start'}
-        css={[
-          css`
-            max-width: 10vw;
-          `,
-        ]}
-      >
-        <Typography variant="subtitle2">
-          {title ?? (kind ? startWithCapitalLetter(kind) : 'Alarm')}
-        </Typography>
-        <Typography variant="desc">{message}</Typography>
-      </Flexbox>
-      <CloseButton mainColor={mainColor} onClick={() => alert('Clicked!')}>
-        <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
-      </CloseButton>
-    </Flexbox>
+              & * {
+                animation: ${bounce(vertical)} 0.6s 0.1s
+                  cubic-bezier(0.34, 1.72, 0.58, 0.85) forwards;
+              }
+            `,
+            V_POSITION_MAP[vertical],
+            H_POSITION_MAP[horizontal],
+          ]}
+        >
+          <ToastIcon kind={kind} size={MAIN_ICON_SIZE} color={mainColor} />
+          <Flexbox
+            flexDirection="column"
+            alignItems={'flex-start'}
+            css={[
+              css`
+                max-width: 10vw;
+              `,
+            ]}
+          >
+            <Typography variant="subtitle2">
+              {title ?? (kind ? startWithCapitalLetter(kind) : 'Alarm')}
+            </Typography>
+            <Typography variant="desc">{message}</Typography>
+          </Flexbox>
+          <CloseButton mainColor={mainColor} onClick={onChangeOpen}>
+            <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
+          </CloseButton>
+        </Flexbox>
+      )}
+    </Portal>
   );
 };
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -95,7 +95,7 @@ const Toast = ({
             </Typography>
             <Typography variant="desc">{message}</Typography>
           </Flexbox>
-          <CloseButton mainColor={mainColor} onClick={onClose}>
+          <CloseButton color={mainColor} onClick={onClose}>
             <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
           </CloseButton>
         </Flexbox>
@@ -128,10 +128,10 @@ const bounce = (vertical: string) => keyframes`
 `;
 
 interface CloseButtonProps {
-  mainColor: string;
+  color: string;
 }
 
-const CloseButton = styled.button<CloseButtonProps>(({ mainColor, theme }) => {
+const CloseButton = styled.button<CloseButtonProps>(({ color, theme }) => {
   const { color: themeColor } = theme;
   const { white } = themeColor;
 
@@ -145,7 +145,7 @@ const CloseButton = styled.button<CloseButtonProps>(({ mainColor, theme }) => {
     cursor: 'pointer',
 
     ':hover': {
-      backgroundColor: `${mainColor}`,
+      backgroundColor: `${color}`,
 
       svg: {
         fill: `${white}`,

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -127,11 +127,11 @@ const bounce = (vertical: string) => keyframes`
   }
 `;
 
-interface ClosebuttonProps {
+interface CloseButtonProps {
   mainColor: string;
 }
 
-const CloseButton = styled.button<ClosebuttonProps>(({ mainColor, theme }) => {
+const CloseButton = styled.button<CloseButtonProps>(({ mainColor, theme }) => {
   const { color: themeColor } = theme;
   const { white } = themeColor;
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -67,9 +67,9 @@ const Toast = ({ kind, title, message, vertical, horizontal }: ToastProps) => {
         </Typography>
         <Typography variant="desc">{message}</Typography>
       </Flexbox>
-      <TempButton onClick={() => alert('Clicked!')}>
+      <CloseButton mainColor={mainColor} onClick={() => alert('Clicked!')}>
         <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
-      </TempButton>
+      </CloseButton>
     </Flexbox>
   );
 };
@@ -97,14 +97,29 @@ const bounce = (vertical: string) => keyframes`
   }
 `;
 
-const TempButton = styled.button`
-  display: flex;
-  outline: none;
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
+interface ClosebuttonProps {
+  mainColor: string;
+}
 
-  :hover {
-    background-color: red;
-  }
-`;
+const CloseButton = styled.button<ClosebuttonProps>(({ mainColor, theme }) => {
+  const { color: themeColor } = theme;
+  const { white } = themeColor;
+
+  return {
+    display: 'flex',
+    outline: 'none',
+    border: 'none',
+    padding: '0',
+    borderRadius: '50%',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+
+    ':hover': {
+      backgroundColor: `${mainColor}`,
+
+      svg: {
+        fill: `${white}`,
+      },
+    },
+  };
+});

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -34,7 +34,7 @@ const startWithCapitalLetter = (str: string) =>
   str[0].toUpperCase() + str.substring(1);
 
 const Toast = ({
-  kind,
+  kind = 'alert',
   title,
   message,
   vertical,
@@ -44,8 +44,7 @@ const Toast = ({
   onClose,
 }: ToastProps) => {
   const { color: themeColor } = theme;
-  const { white, black } = themeColor;
-  const mainColor = kind ? themeColor[kind] : black;
+  const { white } = themeColor;
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -65,7 +64,7 @@ const Toast = ({
             css`
               position: absolute;
               padding: 1rem;
-              border: 2px solid ${mainColor};
+              border: 2px solid ${themeColor[kind]};
               border-radius: 16px;
               background-color: ${white};
               opacity: 0;
@@ -80,7 +79,11 @@ const Toast = ({
             H_POSITION_MAP[horizontal],
           ]}
         >
-          <ToastIcon kind={kind} size={MAIN_ICON_SIZE} color={mainColor} />
+          <ToastIcon
+            kind={kind}
+            size={MAIN_ICON_SIZE}
+            color={themeColor[kind]}
+          />
           <Flexbox
             flexDirection="column"
             alignItems={'flex-start'}
@@ -91,12 +94,12 @@ const Toast = ({
             ]}
           >
             <Typography variant="subtitle2">
-              {title ?? (kind ? startWithCapitalLetter(kind) : 'Alarm')}
+              {title ?? startWithCapitalLetter(kind)}
             </Typography>
             <Typography variant="desc">{message}</Typography>
           </Flexbox>
-          <CloseButton color={mainColor} onClick={onClose}>
-            <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
+          <CloseButton color={themeColor[kind]} onClick={onClose}>
+            <MdOutlineCancel size={CLOSE_ICON_SIZE} color={themeColor[kind]} />
           </CloseButton>
         </Flexbox>
       )}

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -14,11 +14,13 @@ import {
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { DefaultProps } from '@utils/types/DefaultProps';
+import { useEffect } from 'react';
 import { MdOutlineCancel } from 'react-icons/md';
 
 import ToastIcon from './ToastIcon';
 
 export interface ToastProps extends DefaultProps<HTMLDivElement> {
+  duration?: number;
   kind?: ToastKind;
   title?: string;
   message: string;
@@ -37,12 +39,23 @@ const Toast = ({
   message,
   vertical,
   horizontal,
+  duration = 3000,
   open = false,
   onChangeOpen,
 }: ToastProps) => {
   const { color: themeColor } = theme;
   const { white, black } = themeColor;
   const mainColor = kind ? themeColor[kind] : black;
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onChangeOpen();
+    }, duration);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [open]);
 
   return (
     <Portal>

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -41,7 +41,8 @@ const Toast = ({
   onChangeOpen,
 }: ToastProps) => {
   const { color: themeColor } = theme;
-  const mainColor = kind ? themeColor[kind] : '';
+  const { white, black } = themeColor;
+  const mainColor = kind ? themeColor[kind] : black;
 
   return (
     <Portal>
@@ -53,6 +54,7 @@ const Toast = ({
               padding: 1rem;
               border: 2px solid ${mainColor};
               border-radius: 16px;
+              background-color: ${white};
               opacity: 0;
               animation: ${fadeIn} 0.01s 0.1s linear forwards;
 

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -27,7 +27,7 @@ export interface ToastProps extends DefaultProps<HTMLDivElement> {
   vertical: VerticalVariant;
   horizontal: HorizontalVariant;
   open: boolean;
-  onChangeOpen: () => void;
+  onClose: () => void;
 }
 
 const startWithCapitalLetter = (str: string) =>
@@ -41,7 +41,7 @@ const Toast = ({
   horizontal,
   duration = 3000,
   open = false,
-  onChangeOpen,
+  onClose,
 }: ToastProps) => {
   const { color: themeColor } = theme;
   const { white, black } = themeColor;
@@ -49,7 +49,7 @@ const Toast = ({
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      onChangeOpen();
+      onClose();
     }, duration);
 
     return () => {
@@ -95,7 +95,7 @@ const Toast = ({
             </Typography>
             <Typography variant="desc">{message}</Typography>
           </Flexbox>
-          <CloseButton mainColor={mainColor} onClick={onChangeOpen}>
+          <CloseButton mainColor={mainColor} onClick={onClose}>
             <MdOutlineCancel size={CLOSE_ICON_SIZE} color={mainColor} />
           </CloseButton>
         </Flexbox>

--- a/src/components/Toast/useToast.ts
+++ b/src/components/Toast/useToast.ts
@@ -1,17 +1,17 @@
 import { useState } from 'react';
 
-const useToast = () => {
-  const [open, setOpen] = useState<boolean>(false);
+const useToast = (isOpen = false) => {
+  const [open, setOpen] = useState<boolean>(isOpen);
 
-  const handleOpen = () => {
+  const onOpenToast = () => {
     setOpen(true);
   };
 
-  const handleClose = () => {
+  const onCloseToast = () => {
     setOpen(false);
   };
 
-  return { open, setOpen, handleOpen, handleClose };
+  return { open, setOpen, onOpenToast, onCloseToast };
 };
 
 export default useToast;

--- a/src/components/Toast/useToast.ts
+++ b/src/components/Toast/useToast.ts
@@ -1,0 +1,17 @@
+import { useState } from 'react';
+
+const useToast = () => {
+  const [open, setOpen] = useState<boolean>(false);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return { open, setOpen, handleOpen, handleClose };
+};
+
+export default useToast;

--- a/src/components/Toast/useToast.ts
+++ b/src/components/Toast/useToast.ts
@@ -1,17 +1,22 @@
 import { useState } from 'react';
 
-const useToast = (isOpen = false) => {
-  const [open, setOpen] = useState<boolean>(isOpen);
+const useToast = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState<boolean>(initialState);
 
-  const onOpenToast = () => {
-    setOpen(true);
+  const openToast = () => {
+    setIsOpen(true);
   };
 
-  const onCloseToast = () => {
-    setOpen(false);
+  const closeToast = () => {
+    setIsOpen(false);
   };
 
-  return { open, setOpen, onOpenToast, onCloseToast };
+  const toastProps = {
+    open: isOpen,
+    onClose: closeToast,
+  };
+
+  return { openToast, closeToast, toastProps };
 };
 
 export default useToast;

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -5,6 +5,7 @@ export const COLOR = {
   primary400: '#003D99',
   primary500: '#002579',
 
+  alert: '#333333',
   info: '#1493FF',
   success: '#36B37E',
   warning: '#FFAB00',

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -1,7 +1,7 @@
 import { Interpolation, Theme } from '@emotion/react';
 import { pixelToRem } from '@utils/pixelToRem';
 
-export type ToastKind = 'info' | 'success' | 'warning' | 'error';
+export type ToastKind = 'alert' | 'info' | 'success' | 'warning' | 'error';
 
 export type VerticalVariant = 'top' | 'bottom';
 


### PR DESCRIPTION
## 🤠 개요

- #74 
- 기존에 UI적인 부분만 만들어놓았던 Toast 컴포넌트를 실제로 다른 곳에서 사용할 수 있도록 커스텀 훅을 추가 정의했습니다. 

## 💫 설명

- useToast.ts 에 open 상태를 제어할 수 있는 커스텀 훅을 만들었습니다. 

  - WithToastHook 스토리에서 확인할 수 있듯이 커스텀 훅에서 제공하는 함수를 이벤트 핸들러로 등록하여 Toast 를 띄울 수 있습니다. 

  - 이를 위해서 추가적으로 open 과 onChangeOpen 을 Props 에 추가했습니다. 

- Toast 컴포넌트가 자동으로 꺼질 수 있도록 duration Props 를 받습니다. ( default = 3000 = 3초 )

  - 10초동안 떠있는 스토리를 CustomDuration 에서 확인할 수 있습니다. 

- Toast 내부 닫는 버튼 (CloseButton) 에 Button 컴포넌트를 사용하려고 했지만, 수정해야 하는 스타일이 많을 것 같아서
   내부에서 스타일 컴포넌트를 정의해서 사용했습니다. 

- 그 외 사소한 스타일 변경을 했습니다. 

  - Toast 컴포넌트의 배경색을 명시적으로 부여했습니다. 

  - 기존에는 mainColor의 default 값이 빈 문자열이었는데, black 값을 주도록 변경했습니다. 

  - Toast 애니메이션 딜레이가 너무 늦어서 0.1초로 변경하여 이제 더 빨리 동작합니다. 

## 📷 스크린샷 (Optional)

- WithToastHook 스토리 : 3초 후에 사라지고 X 버튼을 누르면 사라집니다.

https://user-images.githubusercontent.com/31645195/227269367-7b8a87cb-b78e-4f21-b154-7e4e6848d220.mov