### PR TITLE
Feat/use-safe-context: Context null check 공통 훅 추가

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -5,15 +5,9 @@ import styled from '@emotion/styled';
 import { pixelToRem } from '@utils/pixelToRem';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { debounce, throttle } from 'lodash';
-import {
-  useState,
-  useRef,
-  useEffect,
-  useContext,
-  createContext,
-  Children,
-} from 'react';
+import { useState, useRef, useEffect, createContext, Children } from 'react';
 import { MdArrowBackIosNew, MdArrowForwardIos } from 'react-icons/md';
+import useSafeContext from 'src/hooks/useSafeContext';
 
 import NavigationButton from './NavigationButton';
 
@@ -54,14 +48,6 @@ const getCardSize = ({
     ...newCardSize,
     translateX: newCardSize.gap + Math.floor(newCardSize.cardWidth / 5),
   };
-};
-
-const useCarouselContext = () => {
-  const context = useContext(CarouselContext);
-  if (context === null) {
-    throw new Error('useTabsContext should be used within Tabs');
-  }
-  return context;
 };
 
 const Carousel = ({ line = 1, children, width, height }: CarouselProps) => {
@@ -173,8 +159,8 @@ const Carousel = ({ line = 1, children, width, height }: CarouselProps) => {
 };
 
 const Card = ({ children }: DefaultPropsWithChildren<HTMLDivElement>) => {
-  const context = useCarouselContext();
-  const { cardWidth, gap, cardHeight, translateX } = context;
+  const { cardWidth, gap, cardHeight, translateX } =
+    useSafeContext(CarouselContext);
   return (
     <CardView {...{ cardWidth, gap, cardHeight, translateX }}>
       <div style={{ transform: `translateX(${translateX}px)`, width: '100%' }}>
@@ -184,8 +170,7 @@ const Card = ({ children }: DefaultPropsWithChildren<HTMLDivElement>) => {
   );
 };
 const Slide = ({ children }: DefaultPropsWithChildren<HTMLDivElement>) => {
-  const context = useCarouselContext();
-  const { cardHeight } = context;
+  const { cardHeight } = useSafeContext(CarouselContext);
   return <SlideView {...{ cardHeight }}>{children}</SlideView>;
 };
 

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -13,11 +13,11 @@ import {
   MouseEventHandler,
   ReactElement,
   SetStateAction,
-  useContext,
   useEffect,
   useRef,
   useState,
 } from 'react';
+import useSafeContext from 'src/hooks/useSafeContext';
 
 type DropdownProps = {
   label: string;
@@ -83,11 +83,8 @@ const Dropdown = ({
 };
 
 const Trigger = ({ children }: { children: ReactElement }) => {
-  const context = useContext(DropdownContext);
-
-  if (!context) return <></>;
-
-  const { isOpen, setIsOpen, label, setTriggerSize } = context;
+  const { isOpen, setIsOpen, label, setTriggerSize } =
+    useSafeContext(DropdownContext);
 
   useEffect(() => {
     const $trigger = document.getElementById(`${label}-trigger`);
@@ -123,13 +120,10 @@ const Trigger = ({ children }: { children: ReactElement }) => {
 };
 
 const Menu = ({ children }: ChildrenProps) => {
-  const context = useContext(DropdownContext);
   const menuRef = useRef<HTMLDivElement | null>(null);
 
-  if (!context) return <></>;
-
   const { isOpen, setIsOpen, collapseOnBlur, label, direction, triggerSize } =
-    context;
+    useSafeContext(DropdownContext);
 
   const toggleEventHandler = (e: MouseEvent) => {
     if (!isOpen) return;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -9,10 +9,10 @@ import {
   SetStateAction,
   createContext,
   forwardRef,
-  useContext,
   useEffect,
 } from 'react';
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
+import useSafeContext from 'src/hooks/useSafeContext';
 
 import useSelect from './useSelect';
 
@@ -42,11 +42,7 @@ const Select = ({ id, setValue, children }: SelectProps) => {
 };
 
 const Trigger = ({ children }: ChildrenProps) => {
-  const dropdownContext = useContext(DropdownContext);
-  if (!dropdownContext) {
-    return <></>;
-  }
-  const { isOpen } = dropdownContext;
+  const { isOpen } = useSafeContext(DropdownContext);
 
   const { color } = useTheme();
   const { gray200, white, black } = color;
@@ -106,20 +102,13 @@ type OptionProps = {
 } & ChildrenProps;
 
 const Option = ({ value, children }: OptionProps) => {
-  const context = useContext(SelectContext);
-  if (!context) return <></>;
-
-  const { selectValue, registerOption } = context;
+  const { selectValue, registerOption } = useSafeContext(SelectContext);
 
   useEffect(() => {
     registerOption(value);
   }, []);
 
-  const dropdownContext = useContext(DropdownContext);
-  if (!dropdownContext) {
-    return <></>;
-  }
-  const { setIsOpen } = dropdownContext;
+  const { setIsOpen } = useSafeContext(DropdownContext);
 
   const onSelect = () => {
     selectValue(value);

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -11,10 +11,10 @@ import {
   KeyboardEvent,
   ReactNode,
   SetStateAction,
-  useContext,
   useRef,
   useState,
 } from 'react';
+import useSafeContext from 'src/hooks/useSafeContext';
 
 type TabsVariant = 'underline' | 'rounded';
 
@@ -66,20 +66,12 @@ const Tabs = ({
   );
 };
 
-const useTabsContext = () => {
-  const context = useContext(TabsContext);
-  if (context === null) {
-    throw new Error('useTabsContext should be used within Tabs');
-  }
-  return context;
-};
-
 interface TabListProps {
   children: ReactNode;
 }
 
 const List = ({ children }: TabListProps) => {
-  const { label } = useTabsContext();
+  const { label } = useSafeContext(TabsContext);
   const { color: themeColor } = useTheme();
   const { gray100 } = themeColor;
 
@@ -153,7 +145,7 @@ const findFutureTrigger = (key: string, currentTrigger: HTMLElement) => {
 
 const Trigger = ({ value, text, icon, disabled = false }: TabTriggerProps) => {
   const { label, variant, isFitted, selectedIndex, setSelectedIndex } =
-    useTabsContext();
+    useSafeContext(TabsContext);
 
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const { color: themeColor } = useTheme();
@@ -295,7 +287,7 @@ interface TabPanelProps {
 }
 
 const Panel = ({ value, children }: TabPanelProps) => {
-  const { label, selectedIndex } = useTabsContext();
+  const { label, selectedIndex } = useSafeContext(TabsContext);
 
   return (
     <Container

--- a/src/hooks/useSafeContext.tsx
+++ b/src/hooks/useSafeContext.tsx
@@ -7,7 +7,7 @@ const useSafeContext: <T extends Context<any>>(
   const context = useContext(Context);
 
   if (!context) {
-    throw new Error('CDS 컴포넌트에 필요한 컨텍스트가 없어요 🥲');
+    throw new Error('CDS 컴포넌트에 필요한 컨텍스트가 없어요!');
   }
 
   return context;

--- a/src/hooks/useSafeContext.tsx
+++ b/src/hooks/useSafeContext.tsx
@@ -1,0 +1,16 @@
+import { Context, useContext } from 'react';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const useSafeContext: <T extends Context<any>>(
+  Context: T,
+) => T extends Context<infer U> ? Exclude<U, null> : never = (Context) => {
+  const context = useContext(Context);
+
+  if (!context) {
+    throw new Error('CDS 컴포넌트에 필요한 컨텍스트가 없어요 🥲');
+  }
+
+  return context;
+};
+
+export default useSafeContext;


### PR DESCRIPTION
## 🤠 개요

- Closes #80 

- 여기저기 써야해서 있는채로 개발하는게 좋을 것 같아서 만들었어요.

## 💫 설명

복잡하지 않아서 설명보다 코드로 보시는게 빨라요. 타입 이슈가 발생하지 않도록 인자로 들어오는 타입에서 null 제외해서 반환하도록 했습니다.

더 좋은 네이밍 의견이 있다면 말씀해주세요 !!!!

```tsx
import { Context, useContext } from 'react';

// eslint-disable-next-line @typescript-eslint/no-explicit-any
const useSafeContext: <T extends Context<any>>(
  Context: T,
) => T extends Context<infer U> ? Exclude<U, null> : never = (Context) => {
  const context = useContext(Context);

  if (!context) {
    throw new Error('CDS 컴포넌트에 필요한 컨텍스트가 없어요 🥲');
  }

  return context;
};

export default useSafeContext;
```