### PR TITLE
Feat/select: Select 컴포넌트 접근성 및 OptGroup 추가

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -101,6 +101,10 @@ const Trigger = ({ children }: { children: ReactElement }) => {
   };
 
   const onKeyDown: KeyboardEventHandler = (e: KeyboardEvent) => {
+    if (children.props.onKeyDown) {
+      children.props.onKeyDown(e);
+    }
+
     if (e.key === SPACE || e.key === ENTER) {
       e.preventDefault();
       setIsOpen((prev) => !prev);

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -135,6 +135,40 @@ MultipleSelects.parameters = {
   },
 };
 
+export const OptGroup: ComponentStory<typeof Select> = () => {
+  const [value, setValue] = useState('');
+
+  return (
+    <Container css={containerStyle}>
+      <form onSubmit={onSubmit} css={formStyle}>
+        <Select id="select" setValue={setValue}>
+          <Select.Trigger>
+            <Badge outline>{value ? value : 'click here'}</Badge>
+          </Select.Trigger>
+          <Select.OptionList>
+            <Select.OptGroup label="Group 1">
+              <Select.Option value="1">1</Select.Option>
+              <Select.Option value="2">2</Select.Option>
+              <Select.Option value="3">3</Select.Option>
+            </Select.OptGroup>
+            <Select.OptGroup label="Group 2">
+              <Select.Option value="4">4</Select.Option>
+              <Select.Option value="5">5</Select.Option>
+              <Select.Option value="6">6</Select.Option>
+            </Select.OptGroup>
+          </Select.OptionList>
+        </Select>
+        <Button text="submit" />
+      </form>
+    </Container>
+  );
+};
+OptGroup.parameters = {
+  docs: {
+    storyDescription: 'OptGroup 요소를 사용하면 옵션을 그루핑 할 수 있습니다.',
+  },
+};
+
 /**
  * utils for story
  */
@@ -145,7 +179,7 @@ const flexColumn = flexboxStyle({
 
 const containerStyle = css`
   width: 375px;
-  height: 375px;
+  height: 406px;
   padding: 0 20px;
   ${flexColumn}
 `;

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -9,50 +9,73 @@ import { FormEventHandler, useState } from 'react';
 import Select from '.';
 
 export default {
-  title: 'Select',
+  title: 'Design System/Components/Select',
   component: Select,
   parameters: {
     layout: 'fullscreen',
     componentSubtitle: 'HTML select 태그의 기능을 제공합니다.',
+    docs: {
+      description: {
+        component:
+          '- 기본 디자인이 적용된 <Select.Trigger>와 <Select.OptionList> 영역으로 나뉩니다.\n' +
+          '- <Select.OptionList> 하위에 <Select.Option> 및 <Select.OptGroup>을 사용해 원하는 옵션을 구성합니다.\n' +
+          '- HTML form 요소 내부에서 사용하면 FormData API를 활용해 값을 가져올 수 있습니다.\n' +
+          '\t- 이 때 select 요소는 props.id와 동일한 id, name을 가집니다.\n' +
+          '\t- 여러 개의 Select를 사용한다면 각각에 고유한 id를 사용해야 합니다.\n' +
+          '- 키보드 컨트롤을 제공합니다.\n' +
+          '\t- 내부적으로 Dropdown 컴포넌트를 사용합니다. Dropdown.Trigger는 tabbable 요소이며 포커스가 있는 상태에서 Enter 키로 Dropdown.Menu를 열 수 있습니다.\n' +
+          '\t- Tab, 위아래 화살표, Enter 키로 옵션을 이동하고 선택할 수 있습니다.\n' +
+          '\t- Esc 키로 옵션 리스트를 닫을 수 있습니다.',
+      },
+    },
   },
   argTypes: {
     id: {
-      label: 'id',
-      type: {
-        name: 'string',
-        required: true,
-      },
       description:
         'select 요소의 id입니다. 어떤 값인지 드러나는 이름이면 좋습니다.',
+      table: {
+        type: {
+          summary: 'string',
+          required: true,
+        },
+        control: { type: 'text' },
+      },
     },
     setValue: {
-      label: 'setValue',
       description:
-        'setState 함수입니다. 옵션 A가 선택되는 경우 setValue(A)가 실행됩니다. 옵셔널 props입니다.',
+        '선택 결과를 외부 상태에 반영하고 싶은 경우 setState 함수를 전달합니다. 옵션 A가 선택되는 경우 setValue(A)가 실행됩니다.',
+      table: {
+        type: {
+          summary: 'Dispatch<SetStateAction<string>>',
+        },
+      },
     },
   },
+  decorators: [
+    (Story) => <Container css={containerStyle}>{Story()}</Container>,
+  ],
 } as ComponentMeta<typeof Select>;
 
-export const Template: ComponentStory<typeof Select> = (args) => {
+const Template: ComponentStory<typeof Select> = (args) => {
   const [value, setValue] = useState('');
 
   return (
-    <Container css={containerStyle}>
-      <Select {...args} setValue={setValue}>
-        <Select.Trigger>
-          <Badge outline>{value ? value : 'click here'}</Badge>
-        </Select.Trigger>
-        <Select.OptionList>
-          <Select.Option value="1">1</Select.Option>
-          <Select.Option value="2">2</Select.Option>
-          <Select.Option value="3">3</Select.Option>
-        </Select.OptionList>
-      </Select>
-    </Container>
+    <Select {...args} setValue={setValue}>
+      <Select.Trigger>
+        <Badge outline>{value ? value : 'click here'}</Badge>
+      </Select.Trigger>
+      <Select.OptionList>
+        <Select.Option value="1">1</Select.Option>
+        <Select.Option value="2">2</Select.Option>
+        <Select.Option value="3">3</Select.Option>
+      </Select.OptionList>
+    </Select>
   );
 };
-Template.args = {
-  id: 'template',
+
+export const Default = Template.bind({});
+Default.args = {
+  id: 'default',
 };
 
 export const UseState = Template.bind({});
@@ -62,7 +85,7 @@ UseState.args = {
 UseState.parameters = {
   docs: {
     storyDescription:
-      '선택 결과를 상태에 반영하고 싶은 경우 props.setValue에 setState 함수를 전달합니다.',
+      '선택된 값에 따라 상태가 변경됩니다. Badge 내부의 텍스트가 이 상태를 사용합니다.',
   },
 };
 
@@ -70,68 +93,25 @@ export const Form: ComponentStory<typeof Select> = () => {
   const [value, setValue] = useState('');
 
   return (
-    <Container css={containerStyle}>
-      <form onSubmit={onSubmit} css={formStyle}>
-        <Select id="form" setValue={setValue}>
-          <Select.Trigger>
-            <Badge outline>{value ? value : 'click here'}</Badge>
-          </Select.Trigger>
-          <Select.OptionList>
-            <Select.Option value="1">1</Select.Option>
-            <Select.Option value="2">2</Select.Option>
-            <Select.Option value="3">3</Select.Option>
-          </Select.OptionList>
-        </Select>
-        <Button text="submit" />
-      </form>
-    </Container>
+    <form onSubmit={onSubmit} css={formStyle}>
+      <Select id="form" setValue={setValue}>
+        <Select.Trigger>
+          <Badge outline>{value ? value : 'click here'}</Badge>
+        </Select.Trigger>
+        <Select.OptionList>
+          <Select.Option value="1">1</Select.Option>
+          <Select.Option value="2">2</Select.Option>
+          <Select.Option value="3">3</Select.Option>
+        </Select.OptionList>
+      </Select>
+      <Button text="submit" />
+    </form>
   );
 };
 Form.parameters = {
   docs: {
-    storyDescription: `HTML form 요소 내부에서 사용하면 FormData API를 활용해 값을 가져올 수 있습니다. 이 때 select 요소는 props.id와 동일한 name을 가집니다.
-      <br />옵션을 선택한 뒤 submit 버튼을 누르면 콘솔에서 선택한 옵션 로그를 확인할 수 있습니다.`,
-  },
-};
-
-export const MultipleSelects: ComponentStory<typeof Select> = () => {
-  const [value, setValue] = useState('');
-  const [anotherValue, setAnotherValue] = useState('');
-
-  return (
-    <Container css={containerStyle}>
-      <form onSubmit={onSubmit} css={formStyle}>
-        <Select id="select" setValue={setValue}>
-          <Select.Trigger>
-            <Badge outline>{value ? value : 'click here'}</Badge>
-          </Select.Trigger>
-          <Select.OptionList>
-            <Select.Option value="1">1</Select.Option>
-            <Select.Option value="2">2</Select.Option>
-            <Select.Option value="3">3</Select.Option>
-          </Select.OptionList>
-        </Select>
-
-        <Select id="another" setValue={setAnotherValue}>
-          <Select.Trigger>
-            <Badge outline>{anotherValue ? anotherValue : 'click here'}</Badge>
-          </Select.Trigger>
-          <Select.OptionList>
-            <Select.Option value="first">first</Select.Option>
-            <Select.Option value="second">second</Select.Option>
-            <Select.Option value="third">third</Select.Option>
-          </Select.OptionList>
-        </Select>
-
-        <Button text="submit" />
-      </form>
-    </Container>
-  );
-};
-MultipleSelects.parameters = {
-  docs: {
     storyDescription:
-      '서로 다른 id를 가지는 여러 개의 select를 사용할 수 있습니다.',
+      'form 요소로 감싼 Select 입니다. 옵션을 선택한 뒤 submit 버튼을 누르면 콘솔에서 선택한 옵션 로그를 확인할 수 있습니다.',
   },
 };
 
@@ -139,28 +119,26 @@ export const OptGroup: ComponentStory<typeof Select> = () => {
   const [value, setValue] = useState('');
 
   return (
-    <Container css={containerStyle}>
-      <form onSubmit={onSubmit} css={formStyle}>
-        <Select id="select" setValue={setValue}>
-          <Select.Trigger>
-            <Badge outline>{value ? value : 'click here'}</Badge>
-          </Select.Trigger>
-          <Select.OptionList>
-            <Select.OptGroup label="Group 1">
-              <Select.Option value="1">1</Select.Option>
-              <Select.Option value="2">2</Select.Option>
-              <Select.Option value="3">3</Select.Option>
-            </Select.OptGroup>
-            <Select.OptGroup label="Group 2">
-              <Select.Option value="4">4</Select.Option>
-              <Select.Option value="5">5</Select.Option>
-              <Select.Option value="6">6</Select.Option>
-            </Select.OptGroup>
-          </Select.OptionList>
-        </Select>
-        <Button text="submit" />
-      </form>
-    </Container>
+    <form onSubmit={onSubmit} css={formStyle}>
+      <Select id="select" setValue={setValue}>
+        <Select.Trigger>
+          <Badge outline>{value ? value : 'click here'}</Badge>
+        </Select.Trigger>
+        <Select.OptionList>
+          <Select.OptGroup label="Group 1">
+            <Select.Option value="1">1</Select.Option>
+            <Select.Option value="2">2</Select.Option>
+            <Select.Option value="3">3</Select.Option>
+          </Select.OptGroup>
+          <Select.OptGroup label="Group 2">
+            <Select.Option value="4">4</Select.Option>
+            <Select.Option value="5">5</Select.Option>
+            <Select.Option value="6">6</Select.Option>
+          </Select.OptGroup>
+        </Select.OptionList>
+      </Select>
+      <Button text="submit" />
+    </form>
   );
 };
 OptGroup.parameters = {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -38,7 +38,6 @@ export default {
           summary: 'string',
           required: true,
         },
-        control: { type: 'text' },
       },
     },
     setValue: {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -48,6 +48,7 @@ export default {
           summary: 'Dispatch<SetStateAction<string>>',
         },
       },
+      control: false,
     },
   },
   decorators: [

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,5 @@
 import Dropdown, { DropdownContext } from '@components/Dropdown';
+import Typography from '@components/Typography';
 import { ARROW_DOWN, ARROW_UP, ENTER, ESC, TAB } from '@constants/key';
 import { css, useTheme } from '@emotion/react';
 import { ChildrenProps } from '@util-types/ChildrenProps';
@@ -126,6 +127,36 @@ const OptionList = ({ children }: ChildrenProps) => {
   );
 };
 
+type OptGroupProps = {
+  label: string;
+} & ChildrenProps;
+
+const OptGroup = ({ label, children }: OptGroupProps) => {
+  const optGroupStyle = css`
+    & > p {
+      padding: 12px 24px;
+    }
+
+    & > div {
+      padding-left: calc(24px + 1rem);
+    }
+  `;
+
+  return (
+    <div css={optGroupStyle}>
+      <Typography
+        color={
+          '#555F6D' // TODO: theme color로 변경
+        }
+        bold
+      >
+        {label}
+      </Typography>
+      {children}
+    </div>
+  );
+};
+
 type OptionProps = {
   value: string;
 } & ChildrenProps;
@@ -226,6 +257,7 @@ HiddenSelect.displayName = 'HiddenSelect';
 
 Select.Trigger = Trigger;
 Select.OptionList = OptionList;
+Select.OptGroup = OptGroup;
 Select.Option = Option;
 
 export default Select;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -25,15 +25,21 @@ type SelectProps = {
 interface SelectContextInterface {
   selectValue: (value: string) => void;
   registerOption: (value: string) => void;
+  selectedOption: string | null;
 }
 const SelectContext = createContext<SelectContextInterface | null>(null);
 
 const Select = ({ id, setValue, children }: SelectProps) => {
-  const { selectRef, selectValue, registerOption } = useSelect(id, setValue);
+  const { selectRef, selectValue, registerOption, selectedOption } = useSelect(
+    id,
+    setValue,
+  );
 
   return (
     <Dropdown label={`select-${id}`} collapseOnBlur={true}>
-      <SelectContext.Provider value={{ selectValue, registerOption }}>
+      <SelectContext.Provider
+        value={{ selectValue, registerOption, selectedOption }}
+      >
         {children}
       </SelectContext.Provider>
       <HiddenSelect id={id} ref={selectRef} />
@@ -108,7 +114,8 @@ type OptionProps = {
 } & ChildrenProps;
 
 const Option = ({ value, children }: OptionProps) => {
-  const { selectValue, registerOption } = useSafeContext(SelectContext);
+  const { selectValue, registerOption, selectedOption } =
+    useSafeContext(SelectContext);
 
   useEffect(() => {
     registerOption(value);
@@ -160,7 +167,7 @@ const Option = ({ value, children }: OptionProps) => {
   };
 
   const { color } = useTheme();
-  const { gray200 } = color;
+  const { white, gray200 } = color;
   const optionStyle = css`
     width: 100%;
     height: 100%;
@@ -169,12 +176,20 @@ const Option = ({ value, children }: OptionProps) => {
 
     &:focus {
       outline: none;
+      color: ${white};
       background-color: ${gray200};
     }
   `;
 
   return (
-    <li onClick={onSelect} tabIndex={0} onKeyDown={onKeyDown} css={optionStyle}>
+    <li
+      onClick={onSelect}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      css={optionStyle}
+      role={'option'}
+      aria-selected={selectedOption === value}
+    >
       {children}
     </li>
   );

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -13,6 +13,7 @@ import {
   SetStateAction,
   createContext,
   forwardRef,
+  useEffect,
   useRef,
 } from 'react';
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
@@ -59,15 +60,19 @@ const Select = ({ id, setValue, children }: SelectProps) => {
 };
 
 const Trigger = ({ children }: ChildrenProps) => {
-  const { isOpen } = useSafeContext(DropdownContext);
+  const { isOpen, setIsOpen } = useSafeContext(DropdownContext);
 
   const { optionRefs, triggerRef } = useSafeContext(SelectContext);
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (e.key === ARROW_DOWN) {
       e.preventDefault();
-      [...optionRefs.current.values()][0].focus();
+      setIsOpen(true);
     }
   };
+
+  useEffect(() => {
+    [...optionRefs.current.values()][0].focus();
+  }, [isOpen]);
 
   const { color } = useTheme();
   const { gray200, white, black } = color;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -64,6 +64,7 @@ const Trigger = ({ children }: ChildrenProps) => {
   const { optionRefs, triggerRef } = useSafeContext(SelectContext);
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (e.key === ARROW_DOWN) {
+      e.preventDefault();
       [...optionRefs.current.values()][0].focus();
     }
   };

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -143,7 +143,11 @@ const OptGroup = ({ label, children }: OptGroupProps) => {
   `;
 
   return (
-    <div css={optGroupStyle}>
+    <div
+      css={optGroupStyle}
+      role="group"
+      aria-details={`${label} option group`}
+    >
       <Typography
         color={
           '#555F6D' // TODO: theme color로 변경

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -72,11 +72,12 @@ const Trigger = ({ children }: ChildrenProps) => {
   };
 
   useEffect(() => {
-    [...optionRefs.current.values()][selectedOption?.index ?? 0].focus();
+    const indexToFocus = selectedOption?.index ?? 0;
+    [...optionRefs.current.values()][indexToFocus].focus();
   }, [isOpen]);
 
-  const { color } = useTheme();
-  const { gray200, white, black } = color;
+  const { color: themeColor } = useTheme();
+  const { gray200, white, black } = themeColor;
 
   const triggerStyle = css`
     display: flex;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -26,10 +26,10 @@ type SelectProps = {
 };
 
 interface SelectContextInterface {
-  optionRefs: MutableRefObject<Map<string, HTMLLIElement>>;
+  optionRefs: MutableRefObject<Map<string, HTMLDivElement>>;
   triggerRef: RefObject<HTMLDivElement>;
   selectValue: (value: string) => void;
-  registerOption: ($li: HTMLLIElement, value: string) => void;
+  registerOption: ($div: HTMLDivElement, value: string) => void;
   selectedOption: string | null;
 }
 const SelectContext = createContext<SelectContextInterface | null>(null);
@@ -119,9 +119,9 @@ const OptionList = ({ children }: ChildrenProps) => {
 
   return (
     <Dropdown.Menu>
-      <ul role="listbox" css={listStyle}>
+      <div role="listbox" css={listStyle}>
         {children}
-      </ul>
+      </div>
     </Dropdown.Menu>
   );
 };
@@ -154,8 +154,8 @@ const Option = ({ value, children }: OptionProps) => {
   const onKeyDown: KeyboardEventHandler = (e) => {
     const { key } = e;
 
-    const $li = optionRefs.current.get(value);
-    if (!$li) return;
+    const $div = optionRefs.current.get(value);
+    if (!$div) return;
 
     if (key === ENTER) {
       onSelect();
@@ -167,12 +167,12 @@ const Option = ({ value, children }: OptionProps) => {
       case TAB:
       case ARROW_DOWN:
         e.preventDefault();
-        getNextElement(options, options.indexOf($li)).focus();
+        getNextElement(options, options.indexOf($div)).focus();
         return;
 
       case ARROW_UP:
         e.preventDefault();
-        getNextElement(options, options.indexOf($li), -1).focus();
+        getNextElement(options, options.indexOf($div), -1).focus();
         return;
 
       case ESC:
@@ -197,8 +197,8 @@ const Option = ({ value, children }: OptionProps) => {
   `;
 
   return (
-    <li
-      ref={($li: HTMLLIElement | null) => $li && registerOption($li, value)}
+    <div
+      ref={($div: HTMLDivElement | null) => $div && registerOption($div, value)}
       onClick={onSelect}
       tabIndex={0}
       onKeyDown={onKeyDown}
@@ -207,7 +207,7 @@ const Option = ({ value, children }: OptionProps) => {
       aria-selected={selectedOption === value}
     >
       {children}
-    </li>
+    </div>
   );
 };
 

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -19,7 +19,7 @@ import {
 import { FiChevronDown, FiChevronUp } from 'react-icons/fi';
 import useSafeContext from 'src/hooks/useSafeContext';
 
-import useSelect from './useSelect';
+import useSelect, { SelectedOption } from './useSelect';
 
 type SelectProps = {
   id: string;
@@ -32,7 +32,7 @@ interface SelectContextInterface {
   triggerRef: RefObject<HTMLDivElement>;
   selectValue: (value: string) => void;
   registerOption: ($div: HTMLDivElement, value: string) => void;
-  selectedOption: string | null;
+  selectedOption: SelectedOption | null;
 }
 const SelectContext = createContext<SelectContextInterface | null>(null);
 
@@ -62,7 +62,8 @@ const Select = ({ id, setValue, children }: SelectProps) => {
 const Trigger = ({ children }: ChildrenProps) => {
   const { isOpen, setIsOpen } = useSafeContext(DropdownContext);
 
-  const { optionRefs, triggerRef } = useSafeContext(SelectContext);
+  const { optionRefs, triggerRef, selectedOption } =
+    useSafeContext(SelectContext);
   const onKeyDown: KeyboardEventHandler<HTMLDivElement> = (e) => {
     if (e.key === ARROW_DOWN) {
       e.preventDefault();
@@ -71,7 +72,7 @@ const Trigger = ({ children }: ChildrenProps) => {
   };
 
   useEffect(() => {
-    [...optionRefs.current.values()][0].focus();
+    [...optionRefs.current.values()][selectedOption?.index ?? 0].focus();
   }, [isOpen]);
 
   const { color } = useTheme();
@@ -252,7 +253,7 @@ const Option = ({ value, children }: OptionProps) => {
       onKeyDown={onKeyDown}
       css={optionStyle}
       role={'option'}
-      aria-selected={selectedOption === value}
+      aria-selected={selectedOption?.value === value}
     >
       {children}
     </div>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -202,6 +202,12 @@ const Option = ({ value, children }: OptionProps) => {
     const options = [...optionRefs.current.values()];
     switch (key) {
       case TAB:
+        if (e.shiftKey) {
+          e.preventDefault();
+          getNextElement(options, options.indexOf($div), -1).focus();
+          break;
+        }
+      // eslint-disable-next-line no-fallthrough
       case ARROW_DOWN:
         e.preventDefault();
         getNextElement(options, options.indexOf($div)).focus();

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -56,6 +56,12 @@ const Trigger = ({ children }: ChildrenProps) => {
     padding: 12px 24px;
     background-color: ${white};
     border: 1.2px solid ${isOpen ? black : gray200};
+    cursor: pointer;
+
+    &:focus {
+      outline: none;
+      border: 1.5px solid ${black};
+    }
   `;
   const chevronStyle = css`
     position: absolute;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -153,6 +153,7 @@ const OptGroup = ({ label, children }: OptGroupProps) => {
           '#555F6D' // TODO: theme color로 변경
         }
         bold
+        aria-hidden={true}
       >
         {label}
       </Typography>

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -4,10 +4,10 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
-  const optionRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+  const optionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
-  const registerOption = ($li: HTMLLIElement, value: string) => {
-    optionRefs.current.set(value, $li);
+  const registerOption = ($div: HTMLDivElement, value: string) => {
+    optionRefs.current.set(value, $div);
 
     const optionId = `${id}-${value}`;
 

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -1,8 +1,14 @@
 import { Dispatch, SetStateAction, useRef, useState } from 'react';
 
+export interface SelectedOption {
+  index: number;
+  value: string;
+}
+
 const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [selectedOption, setSelectedOption] =
+    useState<SelectedOption | null>(null);
 
   const optionRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -25,12 +31,18 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
     if (!selectRef.current) return;
 
     if (setValue) setValue(value);
-    setSelectedOption(value);
 
     const $target = selectRef.current.querySelector(`#${id}-${value}`);
-    selectRef.current.childNodes.forEach(($option) => {
+    selectRef.current.childNodes.forEach(($option, index) => {
       if (!($option instanceof HTMLOptionElement)) return;
-      $option.selected = $option === $target;
+
+      if ($option !== $target) {
+        $option.selected = false;
+        return;
+      }
+
+      $option.selected = true;
+      setSelectedOption({ index, value });
     });
   };
 

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -1,7 +1,8 @@
-import { Dispatch, SetStateAction, useRef } from 'react';
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
 
 const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
   const registerOption = (value: string) => {
     const optionId = `${id}-${value}`;
@@ -17,9 +18,10 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   };
 
   const selectValue = (value: string) => {
-    if (setValue) setValue(value);
-
     if (!selectRef.current) return;
+
+    if (setValue) setValue(value);
+    setSelectedOption(value);
 
     const $target = selectRef.current.querySelector(`#${id}-${value}`);
     selectRef.current.childNodes.forEach(($option) => {
@@ -32,6 +34,7 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
     selectRef,
     registerOption,
     selectValue,
+    selectedOption,
   };
 };
 

--- a/src/components/Select/useSelect.tsx
+++ b/src/components/Select/useSelect.tsx
@@ -4,7 +4,11 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
   const selectRef = useRef<HTMLSelectElement>(null);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
-  const registerOption = (value: string) => {
+  const optionRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+
+  const registerOption = ($li: HTMLLIElement, value: string) => {
+    optionRefs.current.set(value, $li);
+
     const optionId = `${id}-${value}`;
 
     if (!selectRef.current || selectRef.current.querySelector(`#${optionId}`)) {
@@ -32,6 +36,7 @@ const useSelect = (id: string, setValue?: Dispatch<SetStateAction<string>>) => {
 
   return {
     selectRef,
+    optionRefs,
     registerOption,
     selectValue,
     selectedOption,

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,5 +1,6 @@
 import { TYPOGRAPHY } from '@constants/typography';
 import { css, jsx } from '@emotion/react';
+import { DefaultProps } from '@util-types/DefaultProps';
 import { CSSProperties, ReactNode, ReactPortal } from 'react';
 
 type TextNode = Exclude<
@@ -7,7 +8,7 @@ type TextNode = Exclude<
   number | boolean | ReactPortal | null | undefined
 >;
 
-interface TypographyProps {
+interface TypographyProps extends DefaultProps<HTMLParagraphElement> {
   children: TextNode;
   variant?: TypographyVariant;
   color?: CSSProperties['color'];
@@ -34,6 +35,7 @@ const Typography = ({
   variant = 'body',
   color,
   bold,
+  ...props
 }: TypographyProps) => {
   const typography = getTypography(variant);
 
@@ -46,6 +48,7 @@ const Typography = ({
         font-size: ${TYPOGRAPHY[variant].size};
         font-weight: ${TYPOGRAPHY[variant].weight + (bold ? 300 : 0)};
       `,
+      ...props,
     },
     children,
   );

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -11,6 +11,7 @@ interface TypographyProps {
   children: TextNode;
   variant?: TypographyVariant;
   color?: CSSProperties['color'];
+  bold?: boolean;
 }
 
 const getTypography = (variant: TypographyVariant): string => {
@@ -28,7 +29,12 @@ const getTypography = (variant: TypographyVariant): string => {
   }
 };
 
-const Typography = ({ children, variant = 'body', color }: TypographyProps) => {
+const Typography = ({
+  children,
+  variant = 'body',
+  color,
+  bold,
+}: TypographyProps) => {
   const typography = getTypography(variant);
 
   return jsx(
@@ -38,7 +44,7 @@ const Typography = ({ children, variant = 'body', color }: TypographyProps) => {
         margin: 0;
         color: ${color ?? 'inherit'};
         font-size: ${TYPOGRAPHY[variant].size};
-        font-weight: ${TYPOGRAPHY[variant].weight};
+        font-weight: ${TYPOGRAPHY[variant].weight + (bold ? 300 : 0)};
       `,
     },
     children,

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -7,6 +7,8 @@ export const ENTER = 'Enter';
 export const TAB = 'Tab';
 export const SPACE = ' ';
 
+export const ESC = 'Escape';
+
 export const NEXT_KEY = ['37', '38', 'ArrowUp', 'ArrowRight'];
 
 export const PREV_KEY = ['39', '40', 'ArrowLeft', 'ArrowDown'];

--- a/src/utils/getNextElement.ts
+++ b/src/utils/getNextElement.ts
@@ -1,0 +1,17 @@
+export const getNextElement: <T>(
+  array: T[],
+  currentIndex: number,
+  step?: number,
+) => T = (array, currentIndex, step = 1) => {
+  let nextIndex = currentIndex + step;
+
+  while (nextIndex < 0) {
+    nextIndex += array.length;
+  }
+
+  while (array.length <= nextIndex) {
+    nextIndex -= array.length;
+  }
+
+  return array[nextIndex];
+};


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #69 

- Select 컴포넌트 보완 및 기능 추가했습니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->

### 추가된 기능

- [`role="option"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/option_role), `aria-selected` 속성을 추가했습니다.

- <s>Trigger 요소가 열려있는 상태에서 아래 방향키를 누르면 옵션 선택이 가능하도록 했어요.</s>

- Trigger 요소에 포커스가 있는 상태에서 아래 방향키를 누르면 Dropdown.Menu가 열리도록 했어요. (현빈님이 피드백 주셔서 반영한 HTML select 태그의 동작입니다.)

  - 해당 기능을 위해서 Dropdown 파일에도 변경점이 있어요.

- Menu가 열리면 현재 선택된 옵션이 있는 경우는 해당 옵션으로, 아닌 경우 첫번째 옵션으로 focus가 이동합니다.

- Menu가 열려있는 상태에서는 Tab 키로 다음 tabbable 요소가 아닌 다음 옵션을 선택하도록 했어요.

  - 기존에는 Select가 여러개인 경우 마지막 옵션에서 Tab 키를 누르면

    - Menu는 열려있는 상태로

    - 다음 Select의 Trigger로 포커스가 이동했습니다.

  - 조정해야 하는 tabIndex 값이 컴포넌트 외부에 있어 키 이벤트 핸들러를 통해 TAB 키를 아래 방향키와 동일하게 동작하도록 했어요.

  - Tab + Shift 키에는 이전 옵션을 선택하도록 했습니다.

- ESC 키를 눌러 Menu를 닫을 수 있습니다. (HTML select 태그의 동작입니다.)

- OptGroup 요소를 추가합니다. 별도 기능은 없고 label로 입력한 문자열로 옵션들을 그루핑합니다.
 
  <img width="563" alt="image" src="https://user-images.githubusercontent.com/63814960/229071399-34f9e17b-b055-4a33-820d-579e6467efba.png">


### 구현 상세

- useSelect 훅에 옵션 li 노드들을 관리하기 위한 `optionRefs`가 추가되었습니다.

- DOM API를 사용해서 찾던 다음 옵션도 `optionRefs` 정보를 사용하도록 했습니다.

## 📷 스크린샷


https://user-images.githubusercontent.com/63814960/229072328-8211d434-8f55-42a9-9d4e-08fdcb5dcbc2.mov


