### PR TITLE
Docs/story description: 컴포넌트 스토리 타입 정리 및 설명 추가 

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
+    sort: 'requiredFirst',
     matchers: {
       color: /(background|color)$/i,
       date: /Date$/,

--- a/src/components/@layout/Center/Center.stories.tsx
+++ b/src/components/@layout/Center/Center.stories.tsx
@@ -3,25 +3,69 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Center from '.';
 
 export default {
-  title: 'Center',
+  title: 'Design System/Layout/Center',
   component: Center,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle: 'Center는 하위에 있는 children들을 가운데로 정렬합니다.',
+  },
+  argTypes: {
+    children: {
+      name: 'children',
+      description: '중앙에 위치시키고자 하는 요소입니다.',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+      control: {
+        type: 'select',
+        options: {
+          WithChild: <p>안녕하세요</p>,
+          WithChildren: (
+            <div>
+              <div>hi</div>
+              <div>hello</div>
+              <div>안녕</div>
+            </div>
+          ),
+        },
+      },
+    },
   },
 } as ComponentMeta<typeof Center>;
 
-const Template: ComponentStory<typeof Center> = (args) => <Center {...args} />;
+const Template: ComponentStory<typeof Center> = (args) => {
+  return <Center>{args.children}</Center>;
+};
 
-export const Basic = Template.bind({});
-Basic.args = {
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Cold Design System',
+};
+
+export const WithChild = Template.bind({});
+WithChild.args = {
   children: <p>안녕하세요</p>,
 };
 
-export const MultipleLines = Template.bind({});
-MultipleLines.args = {
+WithChild.parameters = {
+  docs: {
+    storyDescription: 'children에 하나의 요소가 존재하는 경우입니다.',
+  },
+};
+
+export const WithChildren = Template.bind({});
+WithChildren.args = {
   children: (
     <div>
-      hi <div>hi</div> <div>ㅗㅑ</div>
+      <div>hi</div>
+      <div>hello</div>
+      <div>안녕</div>
     </div>
   ),
+};
+
+WithChildren.parameters = {
+  docs: {
+    storyDescription: 'children에 여러 요소가 존재하는 경우입니다.',
+  },
 };

--- a/src/components/@layout/Container/Container.stories.tsx
+++ b/src/components/@layout/Container/Container.stories.tsx
@@ -4,14 +4,87 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Container from '.';
 
 export default {
-  title: 'Container',
+  title: 'Design System/Layout/Container',
   component: Container,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Container는 박스 사이즈 안에서 children이 표시될 수 있도록 감쌉니다.',
+  },
+  argTypes: {
+    children: {
+      name: 'children',
+      description: 'Container 내부에 위치하는 요소입니다.',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    overflowX: {
+      name: 'overflowX',
+      description:
+        '너비를 초과하는 요소가 존재할 경우 어떻게 처리할 것인지 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+      defaultValue: 'hidden',
+      control: {
+        type: 'select',
+        options: [
+          'hidden',
+          'visible',
+          'clip',
+          'auto',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    overflowY: {
+      name: 'overflowY',
+      description:
+        '높이를 초과하는 요소가 존재할 경우 어떻게 처리할 것인지 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+      type: { name: 'string', required: true },
+      defaultValue: 'hidden',
+      control: {
+        type: 'select',
+        options: [
+          'hidden',
+          'visible',
+          'clip',
+          'auto',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
   },
 } as ComponentMeta<typeof Container>;
 
-export const Basic: ComponentStory<typeof Container> = (args) => (
+export const Default: ComponentStory<typeof Container> = (args) => {
+  const DUMMY_STR =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. In ligula turpis, fermentum sed nisi vel, faucibus elementum neque. Morbi convallis rutrum lectus id dictum. Pellentesque euismod gravida risus pretium finibus. Pellentesque sollicitudin nunc ligula, et cursus lectus auctor et. Nullam elementum ipsum dui, in ullamcorper velit porta et. Nulla dapibus tristique convallis. Maecenas et tristique velit, non tincidunt dolor. Quisque vitae tincidunt ante. Ut interdum tellus tellus, nec vehicula metus ultricies eget. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec at purus ut justo tempor consequat. Aliquam nec iaculis mi. Donec feugiat velit tincidunt, faucibus magna ac, ullamcorper orci. Proin vitae ipsum et nulla egestas scelerisque. Etiam ac diam in diam faucibus dictum quis quis nibh.';
+
+  return (
+    <Container
+      {...args}
+      css={css`
+        width: 300px;
+        height: 300px;
+        background-color: pink;
+      `}
+    >
+      {DUMMY_STR}
+    </Container>
+  );
+};
+
+export const WithEnoughSpace: ComponentStory<typeof Container> = (args) => (
   <Container
     {...args}
     css={css`
@@ -20,7 +93,8 @@ export const Basic: ComponentStory<typeof Container> = (args) => (
     `}
   />
 );
-Basic.args = {
+
+WithEnoughSpace.args = {
   children: (
     <Container
       css={css`
@@ -32,17 +106,33 @@ Basic.args = {
   ),
 };
 
+WithEnoughSpace.parameters = {
+  docs: {
+    storyDescription:
+      'children을 모두 표시할 정도로 너비와 높이가 충분한 경우 빈 공간이 표시됩니다.',
+  },
+};
+
 export const Scrollable: ComponentStory<typeof Container> = (args) => (
   <Container
     {...args}
     css={css`
-      height: 100px;
+      height: 300px;
+      background-color: pink;
     `}
   />
 );
+
 Scrollable.args = {
   overflowY: 'scroll',
   children: (
-    <div style={{ height: '300px' }}>Container보다 세로로 더 긴 컨텐츠</div>
+    <div style={{ height: '600px' }}>Container보다 세로로 더 긴 컨텐츠</div>
   ),
+};
+
+Scrollable.parameters = {
+  docs: {
+    storyDescription:
+      'Container보다 children의 크기가 클 경우 overflow 속성을 scroll로 설정하여 넘치는 부분을 스크롤로 확인할 수 있습니다.',
+  },
 };

--- a/src/components/@layout/Container/Container.stories.tsx
+++ b/src/components/@layout/Container/Container.stories.tsx
@@ -22,45 +22,27 @@ export default {
     overflowX: {
       name: 'overflowX',
       description:
-        '너비를 초과하는 요소가 존재할 경우 어떻게 처리할 것인지 결정합니다.',
+        '너비를 초과하는 요소가 존재할 경우 어떻게 보여줄 것인지 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['overflowX']" },
+        defaultValue: { summary: 'hidden' },
       },
-      type: { name: 'string', required: true },
-      defaultValue: 'hidden',
       control: {
         type: 'select',
-        options: [
-          'hidden',
-          'visible',
-          'clip',
-          'auto',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['hidden', 'visible', 'clip', 'scroll', 'auto'],
       },
     },
     overflowY: {
       name: 'overflowY',
       description:
-        '높이를 초과하는 요소가 존재할 경우 어떻게 처리할 것인지 결정합니다.',
+        '높이를 초과하는 요소가 존재할 경우 어떻게 보여줄 것인지 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['overflowY']" },
+        defaultValue: { summary: 'hidden' },
       },
-      type: { name: 'string', required: true },
-      defaultValue: 'hidden',
       control: {
         type: 'select',
-        options: [
-          'hidden',
-          'visible',
-          'clip',
-          'auto',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['hidden', 'visible', 'clip', 'scroll', 'auto'],
       },
     },
   },
@@ -133,6 +115,6 @@ Scrollable.args = {
 Scrollable.parameters = {
   docs: {
     storyDescription:
-      'Container보다 children의 크기가 클 경우 overflow 속성을 scroll로 설정하여 넘치는 부분을 스크롤로 확인할 수 있습니다.',
+      '\\<Container\\>보다 children의 크기가 클 경우 overflow 속성을 "scroll"로 설정하여 넘치는 부분을 스크롤로 확인할 수 있습니다.',
   },
 };

--- a/src/components/@layout/Flexbox/Flexbox.stories.tsx
+++ b/src/components/@layout/Flexbox/Flexbox.stories.tsx
@@ -4,10 +4,158 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Flexbox from '.';
 
 export default {
-  title: 'Flexbox',
+  title: 'Design System/Layout/Flexbox',
   component: Flexbox,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Flexbox는 display 속성을 flex로 한 <div> 태그를 선언적으로 사용합니다.',
+  },
+  argTypes: {
+    children: {
+      name: 'children',
+      description: '목록으로 표시되는 요소입니다.',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    flexDirection: {
+      name: 'flexDirection',
+      description: '요소가 배치되는 방향을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'row' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'row',
+          'row-reverse',
+          'column',
+          'column-reverse',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    flexWrap: {
+      name: 'flexWrap',
+      description: '줄바꿈 속성을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'nowrap' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'wrap',
+          'wrap-reverse',
+          'nowrap',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    alignContent: {
+      name: 'alignContent',
+      description:
+        'flex의 교차축을 따라 요소와 주변 공간 배치 방식을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'normal' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'start',
+          'end',
+          'flex-start',
+          'flex-end',
+          'center',
+          'normal',
+          'baseline',
+          'space-between',
+          'space-around',
+          'space-evenly',
+          'stretch',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    alignItems: {
+      name: 'alignItems',
+      description: 'flex의 교차축에 대한 요소 배치 방식을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'center' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'start',
+          'end',
+          'flex-start',
+          'flex-end',
+          'center',
+          'normal',
+          'baseline',
+          'space-between',
+          'space-around',
+          'space-evenly',
+          'stretch',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    justifyContent: {
+      name: 'justifyContent',
+      description:
+        'flex의 주축을 따라 요소와 주변 공간 배치 방식을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'center' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'start',
+          'end',
+          'flex-start',
+          'flex-end',
+          'left',
+          'right',
+          'center',
+          'normal',
+          'space-between',
+          'space-around',
+          'space-evenly',
+          'stretch',
+          'inherit',
+          'initial',
+          'revert',
+          'unset',
+        ],
+      },
+    },
+    gap: {
+      name: 'gap',
+      description: '행과 열 사이의 간격을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '1rem' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    as: { table: { disable: true } },
+    theme: { table: { disable: true } },
   },
 } as ComponentMeta<typeof Flexbox>;
 
@@ -23,21 +171,33 @@ const items = (
 );
 
 const Template: ComponentStory<typeof Flexbox> = (args) => {
-  const commonStyle = css`
-    width: 300px;
-    background-color: #dfdfdf;
-  `;
-
-  return (
-    <Flexbox css={commonStyle} {...args}>
-      {items}
-    </Flexbox>
-  );
+  return <Flexbox {...args}>{items}</Flexbox>;
 };
+
+export const Default = Template.bind({});
 
 export const Row = Template.bind({});
 Row.args = {
   flexDirection: 'row',
+};
+
+Row.parameters = {
+  docs: {
+    storyDescription:
+      'flexDirection 속성을 Row로 설정하면 주축이 가로 방향으로 설정됩니다.',
+  },
+};
+
+export const Column = Template.bind({});
+Column.args = {
+  flexDirection: 'column',
+};
+
+Column.parameters = {
+  docs: {
+    storyDescription:
+      'flexDirection 속성을 Column으로 설정하면 주축이 세로 방향으로 설정됩니다.',
+  },
 };
 
 export const SpaceBetween = Template.bind({});
@@ -46,16 +206,16 @@ SpaceBetween.args = {
   gap: '0rem',
 };
 
-export const Column = Template.bind({});
-Column.args = {
-  flexDirection: 'column',
+SpaceBetween.parameters = {
+  docs: {
+    storyDescription:
+      'justifyContent를 space-between으로 설정하면 처음과 마지막 요소는 양끝에 배치되며 나머지 요소들이 남은 영역에 고른 간격으로 배치됩니다.',
+  },
 };
 
-export const MultiLine: ComponentStory<typeof Flexbox> = (args) => {
+export const WithWrap: ComponentStory<typeof Flexbox> = (args) => {
   const narrowWidthStyle = css`
-    width: 100px;
-    height: 300px;
-    background-color: #dfdfdf;
+    width: 50px;
   `;
 
   return (
@@ -64,7 +224,15 @@ export const MultiLine: ComponentStory<typeof Flexbox> = (args) => {
     </Flexbox>
   );
 };
-MultiLine.args = {
+
+WithWrap.args = {
   flexWrap: 'wrap',
   alignContent: 'center',
+};
+
+WithWrap.parameters = {
+  docs: {
+    storyDescription:
+      'flexWrap 속성을 wrap으로 설정하면 지정된 너비 안에 위치할 수 없는 요소들이 줄바꿈 처리됩니다.',
+  },
 };

--- a/src/components/@layout/Flexbox/Flexbox.stories.tsx
+++ b/src/components/@layout/Flexbox/Flexbox.stories.tsx
@@ -23,47 +23,32 @@ export default {
       name: 'flexDirection',
       description: '요소가 배치되는 방향을 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['flexDirection']" },
         defaultValue: { summary: 'row' },
       },
       control: {
         type: 'select',
-        options: [
-          'row',
-          'row-reverse',
-          'column',
-          'column-reverse',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['row', 'row-reverse', 'column', 'column-reverse'],
       },
     },
     flexWrap: {
       name: 'flexWrap',
       description: '줄바꿈 속성을 설정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['flexWrap']" },
         defaultValue: { summary: 'nowrap' },
       },
       control: {
         type: 'select',
-        options: [
-          'wrap',
-          'wrap-reverse',
-          'nowrap',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['wrap', 'wrap-reverse', 'nowrap'],
       },
     },
     alignContent: {
       name: 'alignContent',
       description:
-        'flex의 교차축을 따라 요소와 주변 공간 배치 방식을 결정합니다.',
+        'flex의 교차축을 따라 요소와 간격 배치 방식을 결정합니다. 줄바꿈이 일어나는 경우 적용되며 이 경우 alignItems 속성은 무시됩니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['alignContent']" },
         defaultValue: { summary: 'normal' },
       },
       control: {
@@ -80,9 +65,6 @@ export default {
           'space-around',
           'space-evenly',
           'stretch',
-          'inherit',
-          'initial',
-          'unset',
         ],
       },
     },
@@ -90,7 +72,7 @@ export default {
       name: 'alignItems',
       description: 'flex의 교차축에 대한 요소 배치 방식을 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['alignItems']" },
         defaultValue: { summary: 'center' },
       },
       control: {
@@ -107,9 +89,6 @@ export default {
           'space-around',
           'space-evenly',
           'stretch',
-          'inherit',
-          'initial',
-          'unset',
         ],
       },
     },
@@ -118,7 +97,7 @@ export default {
       description:
         'flex의 주축을 따라 요소와 주변 공간 배치 방식을 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['justifyContent']" },
         defaultValue: { summary: 'center' },
       },
       control: {
@@ -136,10 +115,6 @@ export default {
           'space-around',
           'space-evenly',
           'stretch',
-          'inherit',
-          'initial',
-          'revert',
-          'unset',
         ],
       },
     },
@@ -147,7 +122,7 @@ export default {
       name: 'gap',
       description: '행과 열 사이의 간격을 설정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['gap']" },
         defaultValue: { summary: '1rem' },
       },
       control: {
@@ -184,7 +159,7 @@ Row.args = {
 Row.parameters = {
   docs: {
     storyDescription:
-      'flexDirection 속성을 Row로 설정하면 주축이 가로 방향으로 설정됩니다.',
+      'flexDirection 속성을 "row"로 설정하면 주축이 가로 방향으로 설정됩니다.',
   },
 };
 
@@ -196,7 +171,7 @@ Column.args = {
 Column.parameters = {
   docs: {
     storyDescription:
-      'flexDirection 속성을 Column으로 설정하면 주축이 세로 방향으로 설정됩니다.',
+      'flexDirection 속성을 "column"으로 설정하면 주축이 세로 방향으로 설정됩니다.',
   },
 };
 
@@ -209,7 +184,7 @@ SpaceBetween.args = {
 SpaceBetween.parameters = {
   docs: {
     storyDescription:
-      'justifyContent를 space-between으로 설정하면 처음과 마지막 요소는 양끝에 배치되며 나머지 요소들이 남은 영역에 고른 간격으로 배치됩니다.',
+      'justifyContent를 "space-between"으로 설정하면 처음과 마지막 요소는 양끝에 배치되며 나머지 요소들이 남은 영역에 고른 간격으로 배치됩니다.',
   },
 };
 
@@ -233,6 +208,6 @@ WithWrap.args = {
 WithWrap.parameters = {
   docs: {
     storyDescription:
-      'flexWrap 속성을 wrap으로 설정하면 지정된 너비 안에 위치할 수 없는 요소들이 줄바꿈 처리됩니다.',
+      'flexWrap 속성을 "wrap"으로 설정하면 지정된 너비 안에 위치할 수 없는 요소들이 줄바꿈 처리됩니다.',
   },
 };

--- a/src/components/@layout/List/List.stories.tsx
+++ b/src/components/@layout/List/List.stories.tsx
@@ -23,39 +23,24 @@ export default {
       name: 'flexDirection',
       description: '요소가 배치되는 방향을 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['flexDirection']" },
         defaultValue: { summary: 'column' },
       },
       control: {
         type: 'select',
-        options: [
-          'row',
-          'row-reverse',
-          'column',
-          'column-reverse',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['row', 'row-reverse', 'column', 'column-reverse'],
       },
     },
     flexWrap: {
       name: 'flexWrap',
       description: '줄바꿈 속성을 설정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['flexWrap']" },
         defaultValue: { summary: 'nowrap' },
       },
       control: {
         type: 'select',
-        options: [
-          'wrap',
-          'wrap-reverse',
-          'nowrap',
-          'inherit',
-          'initial',
-          'unset',
-        ],
+        options: ['wrap', 'wrap-reverse', 'nowrap'],
       },
     },
     css: { table: { disable: true } },
@@ -86,7 +71,8 @@ Column.args = {};
 
 Column.parameters = {
   docs: {
-    storyDescription: '목록이 세로 방향으로 배치됩니다.',
+    storyDescription:
+      'flexDirection을 설정하지 않거나 "column"일 경우 목록이 세로 방향으로 배치됩니다.',
   },
 };
 
@@ -97,7 +83,8 @@ Row.args = {
 
 Row.parameters = {
   docs: {
-    storyDescription: '목록이 가로 방향으로 배치됩니다.',
+    storyDescription:
+      'flexDirection이 "row"일 경우 목록이 가로 방향으로 배치됩니다.',
   },
 };
 
@@ -114,6 +101,6 @@ WithWrap.args = {
 WithWrap.parameters = {
   docs: {
     storyDescription:
-      'flexWrap 속성을 wrap으로 설정하여 제한된 높이 안에서 다중 목록을 표현할 수 있습니다.',
+      'flexWrap 속성을 "wrap"으로 설정하여 제한된 높이 안에서 다중 목록을 표현할 수 있습니다.',
   },
 };

--- a/src/components/@layout/List/List.stories.tsx
+++ b/src/components/@layout/List/List.stories.tsx
@@ -4,10 +4,65 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import List from '.';
 
 export default {
-  title: 'List',
+  title: 'Design System/Layout/List',
   component: List,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'List는 하위에 <li> 태그로 된 children들을 목록 형태로 표시하는 <ul> 태그 역할을 합니다.',
+  },
+  argTypes: {
+    children: {
+      name: 'children',
+      description: '목록으로 표시되는 요소입니다.',
+      table: {
+        type: { summary: 'ReactNode' },
+      },
+    },
+    flexDirection: {
+      name: 'flexDirection',
+      description: '요소가 배치되는 방향을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'column' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'row',
+          'row-reverse',
+          'column',
+          'column-reverse',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    flexWrap: {
+      name: 'flexWrap',
+      description: '줄바꿈 속성을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'nowrap' },
+      },
+      control: {
+        type: 'select',
+        options: [
+          'wrap',
+          'wrap-reverse',
+          'nowrap',
+          'inherit',
+          'initial',
+          'unset',
+        ],
+      },
+    },
+    css: { table: { disable: true } },
+    alignContent: { table: { disable: true } },
+    alignItems: { table: { disable: true } },
+    justifyContent: { table: { disable: true } },
+    gap: { table: { disable: true } },
   },
 } as ComponentMeta<typeof List>;
 
@@ -24,30 +79,41 @@ const Template: ComponentStory<typeof List> = (args) => {
   );
 };
 
-const commonStyle = css`
-  width: 300px;
-  background-color: #dfdfdf;
-`;
+export const Default = Template.bind({});
 
-export const Basic = Template.bind({});
-Basic.args = {
-  css: commonStyle,
+export const Column = Template.bind({});
+Column.args = {};
+
+Column.parameters = {
+  docs: {
+    storyDescription: '목록이 세로 방향으로 배치됩니다.',
+  },
 };
 
-export const MultiLine = Template.bind({});
-MultiLine.args = {
+export const Row = Template.bind({});
+Row.args = {
+  flexDirection: 'row',
+};
+
+Row.parameters = {
+  docs: {
+    storyDescription: '목록이 가로 방향으로 배치됩니다.',
+  },
+};
+
+export const WithWrap = Template.bind({});
+WithWrap.args = {
   flexWrap: 'wrap',
-  alignContent: 'space-around',
   css: [
-    commonStyle,
     css`
       height: 100px;
     `,
   ],
 };
 
-export const Row = Template.bind({});
-Row.args = {
-  flexDirection: 'row',
-  css: commonStyle,
+WithWrap.parameters = {
+  docs: {
+    storyDescription:
+      'flexWrap 속성을 wrap으로 설정하여 제한된 높이 안에서 다중 목록을 표현할 수 있습니다.',
+  },
 };

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -148,13 +148,22 @@ const SlideTemplate: ComponentStory<typeof Carousel> = (args) => {
 };
 
 export const WithCarouselSlide = SlideTemplate.bind({});
-WithCarouselSlide.args = {
-  height: 500,
-};
 
 WithCarouselSlide.parameters = {
   docs: {
     storyDescription:
       '<Carousel.Slide>를 사용한 Slide 형식의 기본 Carousel입니다.',
+  },
+};
+
+export const WithCustomSlideHeight = SlideTemplate.bind({});
+WithCustomSlideHeight.args = {
+  height: 500,
+};
+
+WithCustomSlideHeight.parameters = {
+  docs: {
+    storyDescription:
+      '<Carousel.Slide>와 함께 height에 사용자 지정 값을 전달하여 Carousel 높이를 설정할 수 있습니다.',
   },
 };

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -4,10 +4,46 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Carousel from '.';
 
 export default {
-  title: 'Carousel',
+  title: 'Design System/Components/Carousel',
   component: Carousel,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Carousel은 내부에 있는 요소들을 수평으로 배치하여 좌우로 넘기면서 확인할 수 있는 컴포넌트입니다.',
+    docs: {
+      description: {
+        component: `- 다음과 같은 컴포넌트를 children으로 사용할 수 있습니다.  
+        - \\<Carousel.Card\\> : 여러 개의 카드를 \\<Carousel\\>에 표시하고 좌우로 넘길 수 있습니다.
+        - \\<Carousel.Slide\\> : 한 번에 하나의 요소가 \\<Carousel\\> 내부를 채우도록 만들 때 적용합니다.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    line: {
+      name: 'line',
+      description: 'Carousel 내부 열 개수를 설정합니다.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: 1 },
+      },
+    },
+    width: {
+      name: 'width',
+      description: 'Carousel 아이템의 너비를 px 단위로 설정합니다.',
+      table: {
+        type: { summary: 'number' },
+      },
+      control: false,
+    },
+    height: {
+      name: 'height',
+      description: 'Carousel 아이템의 높이를 px 단위로 설정합니다.',
+      table: {
+        type: { summary: 'number' },
+      },
+      control: false,
+    },
   },
 } as ComponentMeta<typeof Carousel>;
 
@@ -50,6 +86,55 @@ const Template: ComponentStory<typeof Carousel> = (args) => (
   </Carousel>
 );
 
+export const Default = Template.bind({});
+
+export const WithCarouselCard = Template.bind({});
+
+WithCarouselCard.parameters = {
+  docs: {
+    storyDescription:
+      '<Carousel.Card>를 사용한 Card 형식의 기본 Carousel입니다.',
+  },
+};
+
+export const WithCustomLine = Template.bind({});
+WithCustomLine.args = {
+  line: 2,
+};
+
+WithCustomLine.parameters = {
+  docs: {
+    storyDescription: '사용자 지정 line 값으로 열 개수를 설정할 수 있습니다.',
+  },
+};
+
+export const WithCustomSize = Template.bind({});
+WithCustomSize.args = {
+  width: 300,
+  height: 400,
+};
+
+WithCustomSize.parameters = {
+  docs: {
+    storyDescription:
+      '사용자 지정 width와 height로 내부에 표시할 아이템의 크기를 지정할 수 있습니다.',
+  },
+};
+
+export const WithCustomLineAndSize = Template.bind({});
+WithCustomLineAndSize.args = {
+  line: 2,
+  width: 300,
+  height: 400,
+};
+
+WithCustomLineAndSize.parameters = {
+  docs: {
+    storyDescription:
+      'line, width, height 값을 모두 사용자가 지정할 수 있습니다.',
+  },
+};
+
 const SlideTemplate: ComponentStory<typeof Carousel> = (args) => {
   return (
     <Carousel {...args}>
@@ -62,30 +147,14 @@ const SlideTemplate: ComponentStory<typeof Carousel> = (args) => {
   );
 };
 
-export const Inline = Template.bind({});
-export const InlineCustom = Template.bind({});
-InlineCustom.args = {
-  width: 300,
-  height: 400,
-};
-
-export const TwoLine = Template.bind({});
-TwoLine.args = {
-  line: 2,
-};
-export const TwoLineCustom = Template.bind({});
-TwoLineCustom.args = {
-  line: 2,
-  width: 300,
-  height: 400,
-};
-
-export const MultiLine = Template.bind({});
-MultiLine.args = {
-  line: 3,
-};
-
-export const Slide = SlideTemplate.bind({});
-Slide.args = {
+export const WithCarouselSlide = SlideTemplate.bind({});
+WithCarouselSlide.args = {
   height: 500,
+};
+
+WithCarouselSlide.parameters = {
+  docs: {
+    storyDescription:
+      '<Carousel.Slide>를 사용한 Slide 형식의 기본 Carousel입니다.',
+  },
 };

--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -156,12 +156,12 @@ WithCarouselSlide.parameters = {
   },
 };
 
-export const WithCustomSlideHeight = SlideTemplate.bind({});
-WithCustomSlideHeight.args = {
+export const WidthCustomHeight = SlideTemplate.bind({});
+WidthCustomHeight.args = {
   height: 500,
 };
 
-WithCustomSlideHeight.parameters = {
+WidthCustomHeight.parameters = {
   docs: {
     storyDescription:
       '<Carousel.Slide>와 함께 height에 사용자 지정 값을 전달하여 Carousel 높이를 설정할 수 있습니다.',

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,4 +1,5 @@
 import Button from '@components/Button';
+import Center from '@components-layout/Center';
 import Flexbox from '@components-layout/Flexbox';
 import List from '@components-layout/List';
 import { css } from '@emotion/react';
@@ -8,53 +9,112 @@ import { MdPeople } from 'react-icons/md';
 import Dropdown from '.';
 
 export default {
-  title: 'Dropdown',
+  title: 'Design System/Components/Dropdown',
   component: Dropdown,
   parameters: {
     layout: 'fullscreen',
-  },
-  argTypes: {
-    direction: {
-      options: ['left', 'right', 'top', 'bottom'],
-      control: { type: 'select' },
+    componentSubtitle:
+      'Dropdown은 추가적인 메뉴를 담은 컴포넌트가 화면에 나타나도록 제어할 수 있는 트리거를 가지고 있습니다.',
+    docs: {
+      description: {
+        component: `- 다음과 같은 컴포넌트를 children으로 사용할 수 있습니다.  
+        - \\<Dropdown.Trigger\\> : \\<Dropdown.Menu\\>를 열기 위한 이벤트를 제어하는 컴포넌트입니다.
+        - \\<Dropdown.Menu\\> : 사용자가 선택할 수 있는 선택지의 종류를 렌더링하는 컴포넌트입니다.
+        `,
+      },
     },
   },
+  argTypes: {
+    label: {
+      name: 'label',
+      description: '고유한 값으로 접근성 속성에 사용됩니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+      control: {
+        type: 'string',
+      },
+    },
+    collapseOnBlur: {
+      name: 'collapseOnBlur',
+      description:
+        '메뉴가 열렸을 때 메뉴 이외의 영역을 눌렀을 때 메뉴를 닫을 것인지 여부를 설정합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+      },
+      control: {
+        type: 'boolean',
+      },
+    },
+    direction: {
+      name: 'direction',
+      description: '메뉴가 열리는 방향을 선택합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'bottom' },
+      },
+      control: {
+        type: 'select',
+        options: ['left', 'right', 'top', 'bottom'],
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Flexbox
+        justifyContent={'center'}
+        alignItems={'center'}
+        css={css`
+          height: 500px;
+        `}
+      >
+        <Center>
+          <Story />
+        </Center>
+      </Flexbox>
+    ),
+  ],
 } as ComponentMeta<typeof Dropdown>;
 
 const Template: ComponentStory<typeof Dropdown> = (args) => (
-  <Flexbox
-    css={css`
-      height: 300px;
-      width: 300px;
-      justify-content: center;
-      align-items: center;
-    `}
-  >
-    <Dropdown {...args}>
-      <Dropdown.Trigger>
-        <Button text="팀원 목록" icon={MdPeople} variant="light" />
-      </Dropdown.Trigger>
-      <Dropdown.Menu>
-        <List
-          css={css`
-            width: max-content;
-          `}
-        >
-          <li>김세영</li>
-          <li>백도훈</li>
-          <li>이선민</li>
-          <li>이우재</li>
-          <li>이현빈</li>
-          <li>정주연</li>
-        </List>
-      </Dropdown.Menu>
-    </Dropdown>
-  </Flexbox>
+  <Dropdown {...args}>
+    <Dropdown.Trigger>
+      <Button text="팀원 목록" icon={MdPeople} variant="light" />
+    </Dropdown.Trigger>
+    <Dropdown.Menu>
+      <List
+        css={css`
+          width: max-content;
+        `}
+      >
+        <li>김세영</li>
+        <li>백도훈</li>
+        <li>이선민</li>
+        <li>이우재</li>
+        <li>이현빈</li>
+        <li>정주연</li>
+      </List>
+    </Dropdown.Menu>
+  </Dropdown>
 );
 
 export const Default = Template.bind({});
 Default.args = {
+  label: 'dropdown0',
+};
+
+export const DirectionBottom = Template.bind({});
+DirectionBottom.args = {
   label: 'dropdown1',
+  direction: 'bottom',
+};
+
+DirectionBottom.parameters = {
+  docs: {
+    storyDescription:
+      '<Dropdown.Menu>가 열렸을 때 나타나는 방향의 기본값은 하단(bottom)입니다.',
+  },
 };
 
 export const DirectionTop = Template.bind({});
@@ -63,10 +123,24 @@ DirectionTop.args = {
   direction: 'top',
 };
 
+DirectionTop.parameters = {
+  docs: {
+    storyDescription:
+      'direction을 "top"으로 설정하면 <Dropdown.Menu>가 상단에 열립니다.',
+  },
+};
+
 export const DirectionLeft = Template.bind({});
 DirectionLeft.args = {
   label: 'dropdown3',
   direction: 'left',
+};
+
+DirectionLeft.parameters = {
+  docs: {
+    storyDescription:
+      'direction을 "left"로 설정하면 <Dropdown.Menu>가 좌측에 열립니다.',
+  },
 };
 
 export const DirectionRight = Template.bind({});
@@ -75,8 +149,22 @@ DirectionRight.args = {
   direction: 'right',
 };
 
+DirectionRight.parameters = {
+  docs: {
+    storyDescription:
+      'direction을 "right"로 설정하면 <Dropdown.Menu>가 우측에 열립니다.',
+  },
+};
+
 export const CollapseOnBlur = Template.bind({});
 CollapseOnBlur.args = {
   label: 'dropdown5',
   collapseOnBlur: true,
+};
+
+CollapseOnBlur.parameters = {
+  docs: {
+    storyDescription:
+      'collapseOnBlur를 true로 설정하면 <Dropdown.Menu>가 열렸을 때 메뉴 이외의 영역을 클릭했을 경우 메뉴가 닫히도록 설정합니다.',
+  },
 };

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -3,10 +3,56 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Image from '.';
 
 export default {
-  title: 'Image',
+  title: 'Design System/Components/Image',
   component: Image,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Image는 지정된 크기와 모양으로 이미지를 제공하는 컴포넌트입니다.',
+  },
+  argTypes: {
+    src: {
+      name: 'src',
+      description: '이미지가 저장된 경로나 URL을 설정합니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    alt: {
+      name: 'alt',
+      description: '이미지의 대체 텍스트를 설정합니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    size: {
+      name: 'size',
+      description: '이미지 크기를 설정합니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+      control: {
+        type: 'select',
+        options: ['small', 'medium', 'large'],
+      },
+    },
+    shape: {
+      name: 'shape',
+      description: '이미지 모양을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+      control: {
+        type: 'select',
+        options: ['circle', 'rounded'],
+      },
+    },
   },
 } as ComponentMeta<typeof Image>;
 
@@ -17,9 +63,20 @@ const Template: ComponentStory<typeof Image> = (args) => (
   <Image {...args} src={DUMMY_SRC} alt={DUMMY_ALT} />
 );
 
+export const Default = Template.bind({});
+Default.args = {
+  size: 'small',
+};
+
 export const SmallDefault = Template.bind({});
 SmallDefault.args = {
   size: 'small',
+};
+
+SmallDefault.parameters = {
+  docs: {
+    storyDescription: '크기가 small이고 shape을 설정하지 않은 이미지입니다.',
+  },
 };
 
 export const SmallCircle = Template.bind({});
@@ -28,15 +85,33 @@ SmallCircle.args = {
   shape: 'circle',
 };
 
+SmallCircle.parameters = {
+  docs: {
+    storyDescription: '크기가 small이고 모양이 원형인 이미지입니다.',
+  },
+};
+
 export const SmallRounded = Template.bind({});
 SmallRounded.args = {
   size: 'small',
   shape: 'rounded',
 };
 
+SmallRounded.parameters = {
+  docs: {
+    storyDescription: '크기가 small이고 모서리가 둥근 이미지입니다.',
+  },
+};
+
 export const MediumDefault = Template.bind({});
 MediumDefault.args = {
   size: 'medium',
+};
+
+MediumDefault.parameters = {
+  docs: {
+    storyDescription: '크기가 medium이고 shape을 설정하지 않은 이미지입니다.',
+  },
 };
 
 export const MediumCircle = Template.bind({});
@@ -45,15 +120,33 @@ MediumCircle.args = {
   shape: 'circle',
 };
 
+MediumCircle.parameters = {
+  docs: {
+    storyDescription: '크기가 medium이고 모양이 원형인 이미지입니다.',
+  },
+};
+
 export const MediumRounded = Template.bind({});
 MediumRounded.args = {
   size: 'medium',
   shape: 'rounded',
 };
 
+MediumRounded.parameters = {
+  docs: {
+    storyDescription: '크기가 medium이고 모서리가 둥근 이미지입니다.',
+  },
+};
+
 export const LargeDefault = Template.bind({});
 LargeDefault.args = {
   size: 'large',
+};
+
+LargeDefault.parameters = {
+  docs: {
+    storyDescription: '크기가 large이고 shape을 설정하지 않은 이미지입니다.',
+  },
 };
 
 export const LargeCircle = Template.bind({});
@@ -62,8 +155,20 @@ LargeCircle.args = {
   shape: 'circle',
 };
 
+LargeCircle.parameters = {
+  docs: {
+    storyDescription: '크기가 large이고 모양이 원형인 이미지입니다.',
+  },
+};
+
 export const LargeRounded = Template.bind({});
 LargeRounded.args = {
   size: 'large',
   shape: 'rounded',
+};
+
+LargeRounded.parameters = {
+  docs: {
+    storyDescription: '크기가 large이고 모서리가 둥근 이미지입니다.',
+  },
 };

--- a/src/components/RangeSelector/RangeSelector.stories.tsx
+++ b/src/components/RangeSelector/RangeSelector.stories.tsx
@@ -1,13 +1,64 @@
+import Flexbox from '@components-layout/Flexbox';
+import { css } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import RangeSelector from '.';
 
 export default {
-  title: 'RangeSelector',
+  title: 'Design System/Components/RangeSelector',
   component: RangeSelector,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'RangeSelector는 HTML의 <input type="range">처럼 슬라이더를 조절하여 값을 얻을 수 있는 컴포넌트입니다.',
+    docs: {
+      description: {
+        component: `- 다음과 같은 컴포넌트를 children으로 사용할 수 있습니다.  
+        - \\<RangeSelector.Slider> : 값을 조절할 수 있는 Thumb와 Track을 표시합니다.
+        - \\<RangeSelector.RangeDisplay> : \\<RangeSelector\\>에 전달한 최소/최대값을 Track 길이에 맞춰 표시합니다.
+        `,
+      },
+    },
   },
+  argTypes: {
+    id: {
+      name: 'id',
+      description: 'DOM 요소를 고유하게 식별하기 위한 값입니다.',
+    },
+    label: {
+      name: 'label',
+      description: '고유한 값으로 접근성 속성에 사용됩니다.',
+    },
+    min: {
+      name: 'min',
+      description: '최소값을 제한합니다.',
+    },
+    max: {
+      name: 'max',
+      description: '최대값을 제한합니다.',
+    },
+    init: {
+      name: 'init',
+      description: '초기 슬라이드 값을 설정합니다.',
+    },
+    trackWidth: {
+      name: 'trackWidth',
+      description: 'px단위로 Track 길이를 설정합니다.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Flexbox
+        justifyContent={'center'}
+        alignItems={'center'}
+        css={css`
+          height: 200px;
+        `}
+      >
+        <Story />
+      </Flexbox>
+    ),
+  ],
 } as ComponentMeta<typeof RangeSelector>;
 
 const DEFAULT_PROPS = {
@@ -22,12 +73,26 @@ const Template: ComponentStory<typeof RangeSelector> = (args) => (
   </RangeSelector>
 );
 
+export const Default = Template.bind({});
+Default.args = {
+  min: 0,
+  max: 100,
+  init: 50,
+  trackWidth: 200,
+};
+
 export const StartFromZero = Template.bind({});
 StartFromZero.args = {
   min: 0,
   max: 100,
   init: 0,
   trackWidth: 200,
+};
+
+StartFromZero.parameters = {
+  docs: {
+    storyDescription: 'init을 min과 동일하게 설정합니다.',
+  },
 };
 
 export const StartFromHalf = Template.bind({});
@@ -38,12 +103,24 @@ StartFromHalf.args = {
   trackWidth: 200,
 };
 
+StartFromHalf.parameters = {
+  docs: {
+    storyDescription: 'init을 min과 max의 중간값으로 설정합니다.',
+  },
+};
+
 export const StartFromEnd = Template.bind({});
 StartFromEnd.args = {
   min: 0,
   max: 100,
   init: 100,
   trackWidth: 200,
+};
+
+StartFromEnd.parameters = {
+  docs: {
+    storyDescription: 'init을 max와 동일하게 설정합니다.',
+  },
 };
 
 export const MinValueVariant = Template.bind({});
@@ -54,6 +131,12 @@ MinValueVariant.args = {
   trackWidth: 200,
 };
 
+MinValueVariant.parameters = {
+  docs: {
+    storyDescription: '최소값을 0이 아닌 값으로 설정할 수 있습니다.',
+  },
+};
+
 export const MaxValueVariant = Template.bind({});
 MaxValueVariant.args = {
   min: 50,
@@ -62,10 +145,23 @@ MaxValueVariant.args = {
   trackWidth: 200,
 };
 
+MaxValueVariant.parameters = {
+  docs: {
+    storyDescription: '최대값을 100이 아닌 값으로 설정할 수 있습니다.',
+  },
+};
+
 export const SizeVariant = Template.bind({});
 SizeVariant.args = {
   min: 0,
   max: 100,
   init: 50,
   trackWidth: 500,
+};
+
+SizeVariant.parameters = {
+  docs: {
+    storyDescription:
+      'trackWidth를 px 단위로 하여 전체 컴포넌트의 너비가 결정됩니다.',
+  },
 };

--- a/src/components/Spacing/Spacing.stories.tsx
+++ b/src/components/Spacing/Spacing.stories.tsx
@@ -3,10 +3,25 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Spacing from '.';
 
 export default {
-  title: 'Spacing',
+  title: 'Design System/Components/Spacing',
   component: Spacing,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Spacing은 선언적으로 사용할 수 있는 다양한 크기의 여백을 제공합니다.',
+  },
+  argTypes: {
+    size: {
+      name: 'size',
+      description: '여백의 크기를 설정합니다.',
+      table: {
+        type: { summary: 'number' },
+      },
+      control: {
+        type: 'select',
+        options: [5, 10, 15, 20, 30, 40, 60, 80, 100],
+      },
+    },
   },
 } as ComponentMeta<typeof Spacing>;
 
@@ -21,9 +36,17 @@ const Template: ComponentStory<typeof Spacing> = (args) => (
   </>
 );
 
+export const Default = Template.bind({});
+
 export const Size_5 = Template.bind({});
 Size_5.args = {
   size: 5,
+};
+
+Size_5.parameters = {
+  docs: {
+    storyDescription: '5px만큼의 여백을 나타냅니다.',
+  },
 };
 
 export const Size_10 = Template.bind({});
@@ -31,9 +54,21 @@ Size_10.args = {
   size: 10,
 };
 
+Size_10.parameters = {
+  docs: {
+    storyDescription: '10px만큼의 여백을 나타냅니다.',
+  },
+};
+
 export const Size_15 = Template.bind({});
 Size_15.args = {
   size: 15,
+};
+
+Size_15.parameters = {
+  docs: {
+    storyDescription: '15px만큼의 여백을 나타냅니다.',
+  },
 };
 
 export const Size_20 = Template.bind({});
@@ -41,9 +76,21 @@ Size_20.args = {
   size: 20,
 };
 
+Size_20.parameters = {
+  docs: {
+    storyDescription: '20px만큼의 여백을 나타냅니다.',
+  },
+};
+
 export const Size_30 = Template.bind({});
 Size_30.args = {
   size: 30,
+};
+
+Size_30.parameters = {
+  docs: {
+    storyDescription: '30px만큼의 여백을 나타냅니다.',
+  },
 };
 
 export const Size_40 = Template.bind({});
@@ -51,9 +98,21 @@ Size_40.args = {
   size: 40,
 };
 
+Size_40.parameters = {
+  docs: {
+    storyDescription: '40px만큼의 여백을 나타냅니다.',
+  },
+};
+
 export const Size_60 = Template.bind({});
 Size_60.args = {
   size: 60,
+};
+
+Size_60.parameters = {
+  docs: {
+    storyDescription: '60px만큼의 여백을 나타냅니다.',
+  },
 };
 
 export const Size_80 = Template.bind({});
@@ -61,7 +120,19 @@ Size_80.args = {
   size: 80,
 };
 
+Size_80.parameters = {
+  docs: {
+    storyDescription: '80px만큼의 여백을 나타냅니다.',
+  },
+};
+
 export const Size_100 = Template.bind({});
 Size_100.args = {
   size: 100,
+};
+
+Size_100.parameters = {
+  docs: {
+    storyDescription: '100px만큼의 여백을 나타냅니다.',
+  },
 };

--- a/src/components/Spacing/Spacing.stories.tsx
+++ b/src/components/Spacing/Spacing.stories.tsx
@@ -9,13 +9,20 @@ export default {
     layout: 'fullscreen',
     componentSubtitle:
       'Spacing은 선언적으로 사용할 수 있는 다양한 크기의 여백을 제공합니다.',
+    docs: {
+      description: {
+        component:
+          `- size 값으로 5 | 10 | 15 | 20 | 30 | 40 | 60 | 80 | 100 중 하나를 선택할 수 있습니다. \n` +
+          `- 선택한 size 값은 px 단위로 적용됩니다.`,
+      },
+    },
   },
   argTypes: {
     size: {
       name: 'size',
       description: '여백의 크기를 설정합니다.',
       table: {
-        type: { summary: 'number' },
+        type: { summary: 'SpacingVariant' },
       },
       control: {
         type: 'select',

--- a/src/components/Spinner/Spinner.stories.tsx
+++ b/src/components/Spinner/Spinner.stories.tsx
@@ -3,10 +3,26 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Spinner from '.';
 
 export default {
-  title: 'Spinner',
+  title: 'Design System/Components/Spinner',
   component: Spinner,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Spinner는 특정 작업이 완료되거나 표시할 값이 준비될 때까지 사용자가 기다리도록 피드백을 줍니다.',
+  },
+  argTypes: {
+    size: {
+      name: 'size',
+      description: 'Spinner의 크기를 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'small' },
+      },
+      control: {
+        type: 'select',
+        options: ['small', 'large'],
+      },
+    },
   },
 } as ComponentMeta<typeof Spinner>;
 
@@ -14,12 +30,26 @@ const Template: ComponentStory<typeof Spinner> = (args) => (
   <Spinner {...args} />
 );
 
+export const Default = Template.bind({});
+
 export const Small = Template.bind({});
 Small.args = {
   size: 'small',
 };
 
+Small.parameters = {
+  docs: {
+    storyDescription: '작은 크기의 Spinner입니다.',
+  },
+};
+
 export const Large = Template.bind({});
 Large.args = {
   size: 'large',
+};
+
+Large.parameters = {
+  docs: {
+    storyDescription: '큰 크기의 Spinner입니다.',
+  },
 };

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -1,7 +1,7 @@
 import Center from '@components/@layout/Center';
-import Container from '@components/@layout/Container';
-import { ComponentMeta } from '@storybook/react';
-import { ReactNode } from 'react';
+import Flexbox from '@components-layout/Flexbox';
+import { css } from '@emotion/react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import Table, {
   TableHead,
@@ -12,177 +12,266 @@ import Table, {
 } from '.';
 
 export default {
-  title: 'Table',
+  title: 'Design System/Components/Table',
   component: Table,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Table은 행과 열로 이루어진 표 형식으로 나타내야 하는 정보가 있을 경우 사용하기 적합합니다.',
+    docs: {
+      description: {
+        component: `- 다음과 같은 컴포넌트를 children으로 사용할 수 있습니다.  
+        - \\<TableHead\\> : Table의 각 열을 설명하는 요소들을 감싸는 컴포넌트입니다. HTML의 \\<thead\\>에 해당합니다.
+        - \\<TableBody\\> : Table에 표시할 실제 데이터를 감싸는 컴포넌트입니다. HTML의 \\<tbody\\>에 해당합니다.
+        - \\<TableRow\\> : Table 데이터의 각 행을 감싸는 컴포넌트입니다. HTML의 \\<tr\\>에 해당합니다. 
+        - \\<TableHeadData\\> : \\<TableHead\\> 내부에 위치하며 실제 데이터를 나타내는 셀입니다. HTML의 \\<th\\>에 해당합니다. 
+        - \\<TableBodyData\\> : \\<TableBody\\> 내부에 위치하며 실제 데이터를 나타내는 셀입니다. HTML의 \\<td\\>에 해당합니다. 
+        `,
+      },
+    },
   },
+  argTypes: {
+    outline: {
+      name: 'outline',
+      description: 'Table의 테두리 선 유무를 결정합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'Table',
+      },
+      control: {
+        type: 'boolean',
+      },
+    },
+    rounded: {
+      name: 'rounded',
+      description: 'Table의 모서리가 둥근지 여부를 결정합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'Table',
+      },
+      control: {
+        type: 'boolean',
+      },
+    },
+    textColor: {
+      name: 'textColor',
+      description: '글자 색상을 결정합니다.',
+      table: {
+        type: { summary: 'color' },
+        category: 'Common',
+      },
+      control: false,
+    },
+    backgroundColor: {
+      name: 'backgroundColor',
+      description: '배경 색상을 결정합니다.',
+      table: {
+        type: { summary: 'color' },
+        category: 'Common',
+      },
+      control: false,
+    },
+    as: { table: { disable: true } },
+    theme: { table: { disable: true } },
+  },
+  decorators: [
+    (Story) => (
+      <Flexbox
+        justifyContent={'center'}
+        alignItems={'center'}
+        css={css`
+          height: 300px;
+        `}
+      >
+        <Center>
+          <Story />
+        </Center>
+      </Flexbox>
+    ),
+  ],
 } as ComponentMeta<typeof Table>;
 
-const heads = [['column1', 'column2', 'column3']];
-const bodys = [
-  ['data1', 'data2', 'data3'],
-  ['data4', 'data5', 'data6'],
+const DUMMY_HEAD = [['Column1', 'Column2', 'Column3']];
+const DUMMY_BODY = [
+  ['Data1', 'Data2', 'Data3'],
+  ['Data4', 'Data5', 'Data6'],
 ];
 
-const wrapConatiner = (children: ReactNode) => {
-  return (
-    <Center>
-      <Container css={{ width: 500 }}>{children}</Container>
-    </Center>
-  );
+const Template: ComponentStory<typeof Table> = (args) => (
+  <Table {...args}>
+    <TableHead>
+      {DUMMY_HEAD.map((head, index) => (
+        <TableRow key={`head_${index}`}>
+          {head.map((text) => (
+            <TableHeadData key={text}>{text}</TableHeadData>
+          ))}
+        </TableRow>
+      ))}
+    </TableHead>
+    <TableBody>
+      {DUMMY_BODY.map((body, index) => (
+        <TableRow key={`body_${index}`}>
+          {body.map((text) => (
+            <TableBodyData key={text}>{text}</TableBodyData>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+export const Default = Template.bind({});
+
+export const WithOutline = Template.bind({});
+
+WithOutline.args = {
+  outline: true,
 };
 
-export const Origin = () =>
-  wrapConatiner(
-    <Table>
-      <TableHead>
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData key={text}>{text}</TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+WithOutline.parameters = {
+  docs: {
+    storyDescription:
+      'outline 속성을 명시하면 Table에 테두리를 표시할 수 있습니다.',
+  },
+};
 
-export const OnlyOutline = () =>
-  wrapConatiner(
-    <Table outline>
-      <TableHead>
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData key={text}>{text}</TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+export const WithRounded = Template.bind({});
 
-export const HeadBackgroundColor = () =>
-  wrapConatiner(
-    <Table outline>
-      <TableHead backgroundColor="primary100" textColor="white">
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData key={text}>{text}</TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+WithRounded.args = {
+  outline: true,
+  rounded: true,
+};
 
-export const Rounded = () =>
-  wrapConatiner(
-    <Table outline rounded>
-      <TableHead backgroundColor="primary100" textColor="white">
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData key={text}>{text}</TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+WithRounded.parameters = {
+  docs: {
+    storyDescription:
+      'rounded 속성을 명시하면 Table의 모서리에 border-radius를 추가합니다.',
+  },
+};
 
-export const Highlight1 = () =>
-  wrapConatiner(
-    <Table outline rounded>
-      <TableHead backgroundColor="primary100" textColor="white">
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData
-                key={text}
-                textColor={text === 'data5' ? 'primary100' : undefined}
-              >
-                {text}
-              </TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+const TableHeadTemplate: ComponentStory<typeof TableHead> = (args) => (
+  <Table outline>
+    <TableHead {...args}>
+      {DUMMY_HEAD.map((head, index) => (
+        <TableRow key={`head_${index}`}>
+          {head.map((text) => (
+            <TableHeadData key={text}>{text}</TableHeadData>
+          ))}
+        </TableRow>
+      ))}
+    </TableHead>
+    <TableBody>
+      {DUMMY_BODY.map((body, index) => (
+        <TableRow key={`body_${index}`}>
+          {body.map((text) => (
+            <TableBodyData key={text}>{text}</TableBodyData>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
 
-export const Highlight2 = () =>
-  wrapConatiner(
-    <Table outline rounded>
-      <TableHead backgroundColor="primary100" textColor="white">
-        {heads.map((head, index) => (
-          <TableRow key={`head_${index}`}>
-            {head.map((text) => (
-              <TableHeadData key={text}>{text}</TableHeadData>
-            ))}
-          </TableRow>
-        ))}
-      </TableHead>
-      <TableBody>
-        {bodys.map((body, index) => (
-          <TableRow key={`body_${index}`}>
-            {body.map((text) => (
-              <TableBodyData
-                key={text}
-                backgroundColor={text === 'data5' ? 'gray100' : undefined}
-              >
-                {text}
-              </TableBodyData>
-            ))}
-          </TableRow>
-        ))}
-      </TableBody>
-    </Table>,
-  );
+export const WithBackgroundColor = TableHeadTemplate.bind({});
+
+WithBackgroundColor.args = {
+  textColor: 'white',
+  backgroundColor: 'primary100',
+};
+
+WithBackgroundColor.parameters = {
+  docs: {
+    storyDescription:
+      '\\<TableHead\\> 컴포넌트의 textColor와 backgroundColor 속성에 사용자 지정 색상을 전달할 수 있습니다.',
+  },
+};
+
+const BodyDataTextColorTemplate: ComponentStory<typeof TableBodyData> = (
+  args,
+) => (
+  <Table outline>
+    <TableHead backgroundColor="primary100" textColor="white">
+      {DUMMY_HEAD.map((head, index) => (
+        <TableRow key={`head_${index}`}>
+          {head.map((text) => (
+            <TableHeadData key={text}>{text}</TableHeadData>
+          ))}
+        </TableRow>
+      ))}
+    </TableHead>
+    <TableBody>
+      {DUMMY_BODY.map((body, index) => (
+        <TableRow key={`body_${index}`}>
+          {body.map((text) => (
+            <TableBodyData
+              key={text}
+              textColor={text === 'Data5' ? args.textColor : undefined}
+            >
+              {text}
+            </TableBodyData>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+export const WithTextHighlight = BodyDataTextColorTemplate.bind({});
+
+WithTextHighlight.args = {
+  textColor: 'primary100',
+};
+
+WithTextHighlight.parameters = {
+  docs: {
+    storyDescription:
+      '\\<TableBodyData\\> 컴포넌트의 textColor 속성에 사용자 지정 색상을 전달하여 강조할 수 있습니다.',
+  },
+};
+
+const BodyDataBackgroundColorTemplate: ComponentStory<typeof TableBodyData> = (
+  args,
+) => (
+  <Table outline>
+    <TableHead backgroundColor="primary100" textColor="white">
+      {DUMMY_HEAD.map((head, index) => (
+        <TableRow key={`head_${index}`}>
+          {head.map((text) => (
+            <TableHeadData key={text}>{text}</TableHeadData>
+          ))}
+        </TableRow>
+      ))}
+    </TableHead>
+    <TableBody>
+      {DUMMY_BODY.map((body, index) => (
+        <TableRow key={`body_${index}`}>
+          {body.map((text) => (
+            <TableBodyData
+              key={text}
+              backgroundColor={
+                text === 'Data5' ? args.backgroundColor : undefined
+              }
+            >
+              {text}
+            </TableBodyData>
+          ))}
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+export const WithBackgroundHighlight = BodyDataBackgroundColorTemplate.bind({});
+
+WithBackgroundHighlight.args = {
+  backgroundColor: 'gray100',
+};
+
+WithBackgroundHighlight.parameters = {
+  docs: {
+    storyDescription:
+      '\\<TableBodyData\\> 컴포넌트의 backgroundColor 속성에 사용자 지정 색상을 전달하여 강조할 수 있습니다.',
+  },
+};

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -6,10 +6,86 @@ import { MdCelebration, MdInfo, MdCheckCircle } from 'react-icons/md';
 import Tabs from '.';
 
 export default {
-  title: 'Tabs',
+  title: 'Design System/Components/Tabs',
   component: Tabs,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Tabs는 다양한 컨텐츠를 버튼으로 전환할 수 있는 컴포넌트입니다.',
+    docs: {
+      description: {
+        component: `- 다음과 같은 컴포넌트를 children으로 사용할 수 있습니다.  
+        - \\<Tabs.List\\> : Tab을 전환할 수 있는 \\<Tabs.Trigger\\>들을 감싸는 컴포넌트입니다.
+        - \\<Tabs.Trigger\\> : 눌렀을 때 해당 컴포넌트에 대응하는 \\<Tabs.Panel\\>로 화면이 전환됩니다.
+        - \\<Tabs.Panel\\> : \\<Tabs.Trigger\\>를 눌렀을 때 화면에 나타나는 컴포넌트를 감싸는 컴포넌트입니다.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      name: 'label',
+      description: '고유한 값으로 접근성 속성에 사용됩니다.',
+      table: {
+        category: 'Tabs',
+      },
+    },
+    defaultValue: {
+      name: 'defaultValue',
+      description: '초기에 활성화되어 있을 Trigger의 value를 입력합니다.',
+      table: {
+        category: 'Tabs',
+      },
+    },
+    variant: {
+      name: 'variant',
+      description: 'Tabs의 디자인을 선택할 수 있습니다.',
+      table: {
+        defaultValue: { summary: 'underline' },
+        category: 'Tabs',
+      },
+    },
+    isFitted: {
+      name: 'isFitted',
+      description: 'Trigger들이 List의 너비를 꽉 채울지 결정합니다.',
+      table: {
+        defaultValue: { summary: false },
+        category: 'Tabs',
+      },
+    },
+    value: {
+      name: 'value',
+      description: '각각의 Trigger와 Panel을 짝짓기 위한 값입니다.',
+      table: {
+        type: { summary: 'string', required: true },
+        category: ['Tabs.Trigger', 'Tabs.Panel'],
+      },
+    },
+    text: {
+      name: 'text',
+      description: 'Trigger에 표시할 제목을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+        category: 'Tabs.Trigger',
+      },
+    },
+    icon: {
+      name: 'icon',
+      description: 'Trigger에 표시할 아이콘을 설정합니다.',
+      table: {
+        type: { summary: 'string' },
+        category: 'Tabs.Trigger',
+      },
+    },
+    disabled: {
+      name: 'disabled',
+      description: 'Trigger의 비활성화 여부를 결정합니다.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: false },
+        category: 'Tabs.Trigger',
+      },
+    },
   },
 } as ComponentMeta<typeof Tabs>;
 
@@ -48,6 +124,20 @@ Default.args = {
   defaultValue: '1',
 };
 
+export const Underline = Template.bind({});
+Underline.args = {
+  label: '밑줄 있는 Tabs 목록',
+  defaultValue: '1',
+  variant: 'underline',
+};
+
+Underline.parameters = {
+  docs: {
+    storyDescription:
+      'variant가 underline일 경우 선택한 <Tabs.Trigger>에 밑줄이 표시되는 디자인을 적용합니다.',
+  },
+};
+
 export const Rounded = Template.bind({});
 Rounded.args = {
   label: '둥근 Tabs 목록',
@@ -55,26 +145,38 @@ Rounded.args = {
   variant: 'rounded',
 };
 
-export const UnderlineFitted = Template.bind({});
-UnderlineFitted.args = {
-  label: '밑줄이 있으면서 너비가 꽉 찬 Tabs 목록',
+Rounded.parameters = {
+  docs: {
+    storyDescription:
+      'variant가 rounded일 경우 선택한 <Tabs.Trigger>의 상단 모서리가 둥근 디자인을 적용합니다.',
+  },
+};
+
+export const IsFitted = Template.bind({});
+IsFitted.args = {
+  label: '너비가 꽉 찬 Tabs 목록',
   defaultValue: '1',
-  variant: 'underline',
   isFitted: true,
 };
 
-export const RoundedFitted = Template.bind({});
-RoundedFitted.args = {
-  label: '둥글면서 너비가 꽉 찬 Tabs 목록',
-  defaultValue: '1',
-  variant: 'rounded',
-  isFitted: true,
+IsFitted.parameters = {
+  docs: {
+    storyDescription:
+      'isFitted가 true이면 <Tabs.Trigger>들의 너비가 <Tabs.List>를 꽉 채우도록 늘어납니다.',
+  },
 };
 
 export const DefaultValue = Template.bind({});
 DefaultValue.args = {
   label: '기본 값이 설정된 Tabs 목록',
   defaultValue: '3',
+};
+
+DefaultValue.parameters = {
+  docs: {
+    storyDescription:
+      'defaultValue는 처음에 활성화시키고 싶은 <Tabs.Panel>의 value를 전달받아 초기 화면으로 렌더링합니다.',
+  },
 };
 
 const WithIconsTemplate: ComponentStory<typeof Tabs> = (args) => (
@@ -93,6 +195,13 @@ WithIcons.args = {
   defaultValue: '1',
 };
 
+WithIcons.parameters = {
+  docs: {
+    storyDescription:
+      '<Tabs.Trigger>의 icon 속성으로 적절한 react-icons 값을 설정하면 해당 아이콘이 표시됩니다.',
+  },
+};
+
 const WithDisabledTemplate: ComponentStory<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tabs.List>
@@ -107,6 +216,13 @@ export const WithDisabled = WithDisabledTemplate.bind({});
 WithDisabled.args = {
   label: '비활성화 확인용 Tabs 목록',
   defaultValue: '1',
+};
+
+WithDisabled.parameters = {
+  docs: {
+    storyDescription:
+      '<Tabs.Trigger>의 disabled 값을 true로 설정하면 해당 Trigger를 선택할 수 없게 됩니다.',
+  },
 };
 
 const ScrollableTemplate: ComponentStory<typeof Tabs> = (args) => (
@@ -127,6 +243,13 @@ export const Scrollable = ScrollableTemplate.bind({});
 Scrollable.args = {
   label: '스크롤이 생기는 Tabs 목록',
   defaultValue: '1',
+};
+
+Scrollable.parameters = {
+  docs: {
+    storyDescription:
+      '<Tabs.Trigger>들의 너비가 <Tabs.List>를 초과하면 좌우로 스크롤할 수 있습니다.',
+  },
 };
 
 const FocusSelectedTemplate: ComponentStory<typeof Tabs> = (args) => (
@@ -156,4 +279,11 @@ export const FocusSelected = FocusSelectedTemplate.bind({});
 FocusSelected.args = {
   label: '너비가 좁은 Tabs 목록',
   defaultValue: '1',
+};
+
+FocusSelected.parameters = {
+  docs: {
+    storyDescription:
+      '<Tabs.List>에 스크롤이 생기면 선택한 <Tabs.Trigger>로 스크롤합니다.',
+  },
 };

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -15,6 +15,14 @@ export default {
     layout: 'fullscreen',
     componentSubtitle:
       'Toast는 다양한 알림 유형을 제공하여 사용자에게 정보를 전달할 때 사용합니다.',
+    docs: {
+      description: {
+        component:
+          `- kind 값으로 "alert" | "info" | "success" | "warning" | "error" 중 하나를 선택할 수 있습니다. \n` +
+          `- vertical 값으로 "top" | "bottom" 중 하나를 선택할 수 있습니다. \n` +
+          `- horizontal 값으로 "left" | "right" | "center" 중 하나를 선택할 수 있습니다.`,
+      },
+    },
   },
   argTypes: {
     message: {
@@ -28,7 +36,7 @@ export default {
       name: 'vertical',
       description: '수직 방향의 위치를 결정합니다.',
       table: {
-        type: { summary: 'string', required: true },
+        type: { summary: 'VerticalVariant', required: true },
       },
       control: {
         type: 'select',
@@ -39,7 +47,7 @@ export default {
       name: 'horizontal',
       description: '수평 방향의 위치를 결정합니다.',
       table: {
-        type: { summary: 'string', required: true },
+        type: { summary: 'HorizontalVariant', required: true },
       },
       control: {
         type: 'select',
@@ -76,7 +84,7 @@ export default {
       name: 'kind',
       description: 'Toast의 유형을 결정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'ToastKind' },
         defaultValue: { summary: 'alert' },
       },
       control: {
@@ -149,7 +157,7 @@ Alert.args = {
 Alert.parameters = {
   docs: {
     storyDescription:
-      'Alert는 기본 Toast 유형입니다. 색상은 검정색을 사용합니다.',
+      '"alert"는 기본 Toast 유형입니다. 색상은 검정색을 사용합니다.',
   },
 };
 
@@ -164,7 +172,7 @@ Info.args = {
 Info.parameters = {
   docs: {
     storyDescription:
-      'Info는 정보를 알리기 위한 Toast 유형입니다. 색상은 파란색을 사용합니다.',
+      '"info"는 정보를 알리기 위한 Toast 유형입니다. 색상은 파란색을 사용합니다.',
   },
 };
 
@@ -179,7 +187,7 @@ Success.args = {
 Success.parameters = {
   docs: {
     storyDescription:
-      'Success는 성공을 알리기 위한 Toast 유형입니다. 색상은 초록색을 사용합니다.',
+      '"success"는 성공을 알리기 위한 Toast 유형입니다. 색상은 초록색을 사용합니다.',
   },
 };
 
@@ -194,7 +202,7 @@ Warning.args = {
 Warning.parameters = {
   docs: {
     storyDescription:
-      'Warning은 경고를 알리기 위한 Toast 유형입니다. 색상은 노란색을 사용합니다.',
+      '"warning"은 경고를 알리기 위한 Toast 유형입니다. 색상은 노란색을 사용합니다.',
   },
 };
 
@@ -209,7 +217,7 @@ Error.args = {
 Error.parameters = {
   docs: {
     storyDescription:
-      'Error는 에러를 알리기 위한 Toast 유형입니다. 색상은 빨간색을 사용합니다.',
+      '"error"는 에러를 알리기 위한 Toast 유형입니다. 색상은 빨간색을 사용합니다.',
   },
 };
 
@@ -223,7 +231,8 @@ WithTitle.args = {
 
 WithTitle.parameters = {
   docs: {
-    storyDescription: '사용자가 명시적으로 Toast의 제목을 설정할 수 있습니다.',
+    storyDescription:
+      'title 속성으로 사용자가 Toast의 제목을 설정할 수 있습니다.',
   },
 };
 

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,7 @@
 import Button from '@components/Button';
+import Container from '@components-layout/Container';
+import Flexbox from '@components-layout/Flexbox';
+import { css } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import useToast from './useToast';
@@ -6,11 +9,110 @@ import useToast from './useToast';
 import Toast from '.';
 
 export default {
-  title: 'Toast',
+  title: 'Design System/Components/Toast',
   component: Toast,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Toast는 다양한 알림 유형을 제공하여 사용자에게 정보를 전달할 때 사용합니다.',
   },
+  argTypes: {
+    message: {
+      name: 'message',
+      description: 'Toast에서 표시할 내용입니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+    },
+    vertical: {
+      name: 'vertical',
+      description: '수직 방향의 위치를 결정합니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+      control: {
+        type: 'select',
+        options: ['top', 'bottom'],
+      },
+    },
+    horizontal: {
+      name: 'horizontal',
+      description: '수평 방향의 위치를 결정합니다.',
+      table: {
+        type: { summary: 'string', required: true },
+      },
+      control: {
+        type: 'select',
+        options: ['left', 'right', 'center'],
+      },
+    },
+    open: {
+      name: 'open',
+      description: 'Toast가 화면에 나타나는지 여부를 결정합니다.',
+      table: {
+        type: { summary: 'boolean', required: true },
+      },
+      control: false,
+    },
+    onClose: {
+      name: 'onClose',
+      description: '닫기 버튼을 눌렀을 때 동작하는 함수입니다.',
+      table: {
+        type: { summary: 'function', required: true },
+      },
+      control: false,
+    },
+    title: {
+      name: 'title',
+      description: 'Toast에서 표시할 내용 중 제목을 전달합니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+      control: {
+        type: 'text',
+      },
+    },
+    kind: {
+      name: 'kind',
+      description: 'Toast의 유형을 결정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'alert' },
+      },
+      control: {
+        type: 'select',
+        options: ['alert', 'info', 'success', 'warning', 'error'],
+      },
+    },
+    duration: {
+      name: 'duration',
+      description: '지속시간을 설정합니다.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: 3000 },
+      },
+      control: {
+        type: 'number',
+        min: 1000,
+        step: 1000,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Container>
+        <Flexbox
+          justifyContent={'center'}
+          alignItems={'center'}
+          css={css`
+            height: 300px;
+          `}
+        >
+          <Story />
+        </Flexbox>
+      </Container>
+    ),
+  ],
 } as ComponentMeta<typeof Toast>;
 
 const DUMMY_TITLE = '기본 제목을 설정할 수 있습니다.';
@@ -19,109 +121,6 @@ const DUMMY_LONG_MESSAGE =
   '긴 토스트 메세지입니다. 현재 토스트 메세지의 최대 길이는 10vw로 설정되어 있습니다.';
 
 const Template: ComponentStory<typeof Toast> = (args) => {
-  const { toastProps } = useToast(true);
-
-  return <Toast {...args} {...toastProps} />;
-};
-
-export const Alert = Template.bind({});
-Alert.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'alert',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Info = Template.bind({});
-Info.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'info',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Success = Template.bind({});
-Success.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'success',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Warning = Template.bind({});
-Warning.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'warning',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const Error = Template.bind({});
-Error.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  kind: 'error',
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const WithTitle = Template.bind({});
-WithTitle.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  title: DUMMY_TITLE,
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const LongMessage = Template.bind({});
-LongMessage.args = {
-  message: DUMMY_LONG_MESSAGE,
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const TopLeft = Template.bind({});
-TopLeft.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'top',
-  horizontal: 'left',
-};
-
-export const TopCenter = Template.bind({});
-TopCenter.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'top',
-  horizontal: 'center',
-};
-
-export const TopRight = Template.bind({});
-TopRight.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'top',
-  horizontal: 'right',
-};
-
-export const BottomLeft = Template.bind({});
-BottomLeft.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'bottom',
-  horizontal: 'left',
-};
-
-export const BottomCenter = Template.bind({});
-BottomCenter.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'bottom',
-  horizontal: 'center',
-};
-
-export const BottomRight = Template.bind({});
-BottomRight.args = {
-  message: DUMMY_SHORT_MESSAGE,
-  vertical: 'bottom',
-  horizontal: 'right',
-};
-
-const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
   const { openToast, toastProps } = useToast();
 
   return (
@@ -132,7 +131,201 @@ const ToastHookTemplate: ComponentStory<typeof Toast> = (args) => {
   );
 };
 
-export const WithToastHook = ToastHookTemplate.bind({});
+export const Default = Template.bind({});
+Default.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+export const Alert = Template.bind({});
+Alert.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'alert',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+Alert.parameters = {
+  docs: {
+    storyDescription:
+      'Alert는 기본 Toast 유형입니다. 색상은 검정색을 사용합니다.',
+  },
+};
+
+export const Info = Template.bind({});
+Info.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'info',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+Info.parameters = {
+  docs: {
+    storyDescription:
+      'Info는 정보를 알리기 위한 Toast 유형입니다. 색상은 파란색을 사용합니다.',
+  },
+};
+
+export const Success = Template.bind({});
+Success.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'success',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+Success.parameters = {
+  docs: {
+    storyDescription:
+      'Success는 성공을 알리기 위한 Toast 유형입니다. 색상은 초록색을 사용합니다.',
+  },
+};
+
+export const Warning = Template.bind({});
+Warning.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'warning',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+Warning.parameters = {
+  docs: {
+    storyDescription:
+      'Warning은 경고를 알리기 위한 Toast 유형입니다. 색상은 노란색을 사용합니다.',
+  },
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  kind: 'error',
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+Error.parameters = {
+  docs: {
+    storyDescription:
+      'Error는 에러를 알리기 위한 Toast 유형입니다. 색상은 빨간색을 사용합니다.',
+  },
+};
+
+export const WithTitle = Template.bind({});
+WithTitle.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  title: DUMMY_TITLE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+WithTitle.parameters = {
+  docs: {
+    storyDescription: '사용자가 명시적으로 Toast의 제목을 설정할 수 있습니다.',
+  },
+};
+
+export const LongMessage = Template.bind({});
+LongMessage.args = {
+  message: DUMMY_LONG_MESSAGE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+LongMessage.parameters = {
+  docs: {
+    storyDescription:
+      'message 내용이 길 경우 Toast의 최대 너비는 뷰포트 너비의 10%까지 확장됩니다.',
+  },
+};
+
+export const TopLeft = Template.bind({});
+TopLeft.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'top',
+  horizontal: 'left',
+};
+
+TopLeft.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "top"이고 horizontal 값은 "left"인 경우 Toast는 좌상단에 위치합니다.',
+  },
+};
+
+export const TopCenter = Template.bind({});
+TopCenter.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'top',
+  horizontal: 'center',
+};
+
+TopCenter.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "top"이고 horizontal 값은 "center"인 경우 Toast는 상단 중앙에 위치합니다.',
+  },
+};
+
+export const TopRight = Template.bind({});
+TopRight.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'top',
+  horizontal: 'right',
+};
+
+TopRight.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "top"이고 horizontal 값은 "right"인 경우 Toast는 우상단에 위치합니다.',
+  },
+};
+
+export const BottomLeft = Template.bind({});
+BottomLeft.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'bottom',
+  horizontal: 'left',
+};
+
+BottomLeft.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "bottom"이고 horizontal 값은 "left"인 경우 Toast는 좌하단에 위치합니다.',
+  },
+};
+
+export const BottomCenter = Template.bind({});
+BottomCenter.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'bottom',
+  horizontal: 'center',
+};
+
+BottomCenter.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "bottom"이고 horizontal 값은 "center"인 경우 Toast는 하단 중앙에 위치합니다.',
+  },
+};
+
+export const BottomRight = Template.bind({});
+BottomRight.args = {
+  message: DUMMY_SHORT_MESSAGE,
+  vertical: 'bottom',
+  horizontal: 'right',
+};
+
+BottomRight.parameters = {
+  docs: {
+    storyDescription:
+      'vertical 값은 "bottom"이고 horizontal 값은 "right"인 경우 Toast는 우하단에 위치합니다.',
+  },
+};
+
+export const WithToastHook = Template.bind({});
 WithToastHook.args = {
   message: 'X 버튼을 누르면 사라져요.',
   kind: 'info',
@@ -140,11 +333,25 @@ WithToastHook.args = {
   horizontal: 'center',
 };
 
-export const CustomDuration = ToastHookTemplate.bind({});
+WithToastHook.parameters = {
+  docs: {
+    storyDescription:
+      'Toast를 호출할 수 있는 useToast Hook을 Button에 등록할 수 있습니다.',
+  },
+};
+
+export const CustomDuration = Template.bind({});
 CustomDuration.args = {
   message: '10초동안 보입니다.',
   kind: 'info',
   vertical: 'top',
   horizontal: 'center',
   duration: 10000,
+};
+
+CustomDuration.parameters = {
+  docs: {
+    storyDescription:
+      'duration 값을 변경하면 Toast가 자동으로 사라지기까지의 시간을 설정할 수 있습니다.',
+  },
 };

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from '@emotion/react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Highlight from './Highlight';

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -6,27 +6,66 @@ import Highlight from './Highlight';
 import Typography from '.';
 
 export default {
-  title: 'Typography',
+  title: 'Design System/Components/Typography',
   component: Typography,
   parameters: {
     layout: 'fullscreen',
+    componentSubtitle:
+      'Typography는 텍스트의 역할에 따라 다양한 폰트 크기와 굵기를 설정할 수 있습니다.',
+  },
+  argTypes: {
+    children: {
+      name: 'children',
+      description: 'Typography로 나타낼 글 내용입니다.',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    variant: {
+      name: 'variant',
+      description: '텍스트 역할을 선택합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'body' },
+      },
+      type: { name: 'string', required: true },
+      control: {
+        type: 'select',
+        options: ['title1', 'title2', 'subtitle1', 'subtitle2', 'body', 'desc'],
+      },
+    },
+    color: {
+      name: 'color',
+      description: '텍스트 색상을 지정합니다.',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'inherit' },
+      },
+      control: {
+        type: 'color',
+      },
+    },
   },
 } as ComponentMeta<typeof Typography>;
 
 const Template: ComponentStory<typeof Typography> = (args) => {
-  const { color } = useTheme();
-  const { black } = color;
-
   return (
-    <Typography color={black} {...args}>
-      안녕하세요. 콜드스터디 디자인 시스템입니다. 🧊
-    </Typography>
+    <Typography {...args}>안녕하세요. 콜드 디자인 시스템입니다. 🧊</Typography>
   );
 };
+
+export const Default = Template.bind({});
 
 export const Title1 = Template.bind({});
 Title1.args = {
   variant: 'title1',
+};
+
+Title1.parameters = {
+  docs: {
+    storyDescription:
+      '화면에서 가장 중요하고 핵심이 되는 텍스트일 경우 사용합니다.',
+  },
 };
 
 export const Title2 = Template.bind({});
@@ -34,9 +73,21 @@ Title2.args = {
   variant: 'title2',
 };
 
+Title2.parameters = {
+  docs: {
+    storyDescription: 'title1 다음으로 중요한 텍스트일 경우 사용합니다.',
+  },
+};
+
 export const Subtitle1 = Template.bind({});
 Subtitle1.args = {
   variant: 'subtitle1',
+};
+
+Subtitle1.parameters = {
+  docs: {
+    storyDescription: '세부사항 중에서 가장 중요한 텍스트일 경우 사용합니다.',
+  },
 };
 
 export const Subtitle2 = Template.bind({});
@@ -44,9 +95,22 @@ Subtitle2.args = {
   variant: 'subtitle2',
 };
 
+Subtitle2.parameters = {
+  docs: {
+    storyDescription:
+      '세부사항 중에서 subtitle1 다음으로 중요한 텍스트일 경우 사용합니다.',
+  },
+};
+
 export const Body = Template.bind({});
 Body.args = {
   variant: 'body',
+};
+
+Body.parameters = {
+  docs: {
+    storyDescription: '여러 문단으로 된 글이나 일반적인 텍스트에 사용합니다.',
+  },
 };
 
 export const Desc = Template.bind({});
@@ -54,32 +118,51 @@ Desc.args = {
   variant: 'desc',
 };
 
-export const Title1WithColor = Template.bind({});
-Title1WithColor.args = {
-  variant: 'title1',
+Desc.parameters = {
+  docs: {
+    storyDescription:
+      '세부 설명처럼 일반 텍스트보다 작은 크기의 텍스트에 사용합니다.',
+  },
+};
+
+export const WithColor = Template.bind({});
+WithColor.args = {
   color: 'blue',
 };
 
-export const Title1Highlighted: ComponentStory<typeof Typography> = () => {
-  const { color } = useTheme();
-  const { black } = color;
-
-  return (
-    <Typography variant="title1" color={black}>
-      안녕하세요. <Highlight>콜드스터디</Highlight> 디자인 시스템입니다. 🧊
-    </Typography>
-  );
+WithColor.parameters = {
+  docs: {
+    storyDescription: '사용자 지정 색상으로 텍스트 색상을 설정할 수 있습니다.',
+  },
 };
 
-export const Title1CustomHighlighted: ComponentStory<typeof Typography> =
-  () => {
-    const { color } = useTheme();
-    const { black } = color;
+const HighlightTemplate: ComponentStory<typeof Typography> = () => (
+  <Typography>
+    안녕하세요. <Highlight>콜드스터디</Highlight> 디자인 시스템입니다. 🧊
+  </Typography>
+);
 
-    return (
-      <Typography variant="title1" color={black}>
-        안녕하세요. <Highlight color="blue">콜드스터디</Highlight> 디자인
-        시스템입니다. 🧊
-      </Typography>
-    );
-  };
+export const WithHighlight = HighlightTemplate.bind({});
+
+WithHighlight.parameters = {
+  docs: {
+    storyDescription:
+      'Typography 내부에서 강조하고 싶은 단어에 Highlight 컴포넌트를 사용할 수 있습니다.',
+  },
+};
+
+const CustomHighlightTemplate: ComponentStory<typeof Typography> = () => (
+  <Typography>
+    안녕하세요. <Highlight color="orange">콜드스터디</Highlight> 디자인
+    시스템입니다. 🧊
+  </Typography>
+);
+
+export const WithCustomHighlight = CustomHighlightTemplate.bind({});
+
+WithCustomHighlight.parameters = {
+  docs: {
+    storyDescription:
+      '사용자 지정 색상으로 Highlight 컴포넌트의 강조 색상을 설정할 수 있습니다.',
+  },
+};

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -11,34 +11,44 @@ export default {
     layout: 'fullscreen',
     componentSubtitle:
       'Typography는 텍스트의 역할에 따라 다양한 폰트 크기와 굵기를 설정할 수 있습니다.',
-  },
-  argTypes: {
-    children: {
-      name: 'children',
-      description: 'Typography로 나타낼 글 내용입니다.',
-      table: {
-        type: { summary: 'string' },
+    docs: {
+      description: {
+        component:
+          `- variant 값으로 "title1" | "title2" | "subtitle1" | "subtitle2" | "body" | "desc" 를 사용할 수 있습니다. \n` +
+          `- 텍스트 부분 하이라이팅을 위해 \\<Highlight\\> 컴포넌트를 함께 사용할 수 있습니다.`,
       },
     },
+  },
+  argTypes: {
     variant: {
       name: 'variant',
       description: '텍스트 역할을 선택합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'TypographyVariant' },
         defaultValue: { summary: 'body' },
+        category: 'Typography',
       },
-      type: { name: 'string', required: true },
       control: {
         type: 'select',
         options: ['title1', 'title2', 'subtitle1', 'subtitle2', 'body', 'desc'],
+      },
+    },
+    children: {
+      name: 'children',
+      description:
+        'Typography로 나타낼 글 내용입니다. 문자로 평가되는 모든 노드가 올 수 있습니다.',
+      table: {
+        type: { summary: 'string' },
+        category: ['Typography', 'Highlight'],
       },
     },
     color: {
       name: 'color',
       description: '텍스트 색상을 지정합니다.',
       table: {
-        type: { summary: 'string' },
+        type: { summary: "CSSProperties['color']" },
         defaultValue: { summary: 'inherit' },
+        category: ['Typography', 'Highlight'],
       },
       control: {
         type: 'color',
@@ -74,7 +84,7 @@ Title2.args = {
 
 Title2.parameters = {
   docs: {
-    storyDescription: 'title1 다음으로 중요한 텍스트일 경우 사용합니다.',
+    storyDescription: '"title1" 다음으로 중요한 텍스트일 경우 사용합니다.',
   },
 };
 
@@ -97,7 +107,7 @@ Subtitle2.args = {
 Subtitle2.parameters = {
   docs: {
     storyDescription:
-      '세부사항 중에서 subtitle1 다음으로 중요한 텍스트일 경우 사용합니다.',
+      '세부사항 중에서 "subtitle1" 다음으로 중요한 텍스트일 경우 사용합니다.',
   },
 };
 
@@ -146,7 +156,7 @@ export const WithHighlight = HighlightTemplate.bind({});
 WithHighlight.parameters = {
   docs: {
     storyDescription:
-      'Typography 내부에서 강조하고 싶은 단어에 Highlight 컴포넌트를 사용할 수 있습니다.',
+      '\\<Typography\\> 내부에서 강조하고 싶은 단어에 \\<Highlight\\> 컴포넌트를 사용할 수 있습니다.',
   },
 };
 
@@ -162,6 +172,6 @@ export const WithCustomHighlight = CustomHighlightTemplate.bind({});
 WithCustomHighlight.parameters = {
   docs: {
     storyDescription:
-      '사용자 지정 색상으로 Highlight 컴포넌트의 강조 색상을 설정할 수 있습니다.',
+      '사용자 지정 색상으로 \\<Highlight\\> 컴포넌트의 강조 색상을 설정할 수 있습니다.',
   },
 };


### PR DESCRIPTION
## 🤠 개요

- #79 
- 지금까지 개발했던 컴포넌트의 스토리를 문서로 정리하는 것을 목표로 합니다. 
- ⛔️ 접근 금지 컴포넌트는 제외했습니다. 
  - 이슈에 있는 접근 금지 컴포넌트 : Select, RadioButton, Modal, Input, Badge
  - RadioButton 이라고 적혀있는데 아직 컴포넌트가 없었고, 그냥 Button도 리팩토링하실 수도 있을 것 같아서 아직 수정하지 않았습니다.

## 💫 설명

- 주요 작업 목표는 
  1) 컴포넌트가 받는 Props Type들이 Docs Table에 불분명하게 나타나는 것을 수정하고
  2) 각각의 스토리의 이름 수정, 순서 재배치
  3) 컴포넌트와 스토리가 무엇을 나타내는지 설명을 추가하는 것이었습니다. 

<br />

- 이번 작업에서 신경쓰지 않았던 점은 
  - 컴포넌트에 이상이 있어 스토리가 잘 렌더링되지 않는 경우와
  - Docs의 Code 영역을 눌렀을 때 나오는 코드 부분입니다. 
  - 요약하면 최대한 컴포넌트 스토리에 대해서 수정하는 것에 주안점을 두었습니다.

<br />

- 컴포넌트 중에서 바닐라 CSS 속성을 그대로 사용하는 경우 스토리에서도 해당 값을 모두 사용해볼 수 있도록 **control** (Default 스토리에 대해서 Props를 조절해볼 수 있는 부분)을 지원하기 위해 select-option 부분 코드가 조금 길어졌습니다. (주로 Layout 컴포넌트)

<br />

- theme이나 as 속성을 사용하는 컴포넌트에서는 사용자가 입력하지 않아도 되는 값이 자동으로 ***Docs Table**(Docs 페이지 상단에 나타나는 Props Type이 정리된 Table)의 props로 취급되는 문제가 있었습니다. 
  - 이런 부분은 컴포넌트 코드를 건들기보다 `theme: { table: { disable: true } }` 처럼 Docs Table에서 숨김처리했습니다. 

<br />

- 스토리에서 공통적으로 적용해야 하는 컴포넌트 (여백을 확보하기 위한 Container, 중앙 정렬을 위한 Flex 등)가 존재하는 경우 기존에 Template에 불필요한 코드가 섞여 있던 점을 `decorators`라는 스토리북 설정을 통해서 해결했습니다. 
  - 오늘 우리가 모던 자바스크립트에서 배웠던 것처럼 스토리를 한번 감싸주는 역할을 합니다. 
  - 그래서 공통적으로 적용되는 컴포넌트를 따로 분리해서 스토리에서는 해당 스토리에 집중할 수 있습니다. 
  - 적용 컴포넌트 예시 : Table, Dropdown, Toast 등 
 
<br />

- 스토리 이름은 되도록이면 `With~` 꼴로 통일했습니다.

## ✊ 앞으로 작업할 액션 아이템
- Plop JS에서 스토리북 템플릿을 사용하도록 기능을 추가했는데, 작업을 하다보니 decorators, category나 docs-description 등 주석으로 추가해놓으면 더 좋을 것 같은 속성들이 있어서 리팩토링 PR 새로 올리도록 하겠습니다. 

<br />

- 작업하다가 제가 만들었던 컴포넌트들이 렌더링 관련하여 말썽을 일으키는 부분이 있어서 hotfix로 따로 PR 올리도록 하겠습니다. (Toast, RangeSelector)


## 🐴 드리는 말
- 개인적으로 초반에 만들었던 컴포넌트와 최근에 만든 컴포넌트들의 코드 퀄리티 차이가 나는 것 같았습니다. 특히 TypeScript 에서요. 
  - TypeScript를 잘 적용한 컴포넌트는 Docs Table에서 별도로 수정을 크게 안해줘도 알아서 잘 추론이 되어서 편했어요.
  - 반대로 Props가 모호하거나 선택지가 지나치게 많은 경우 Docs Table에서 제대로 추론하지 못했어요. 
  - 앞으로 컴포넌트 + 스토리를 다 만들고 Docs 페이지에서 한번 Table을 확인해보는 것도 좋을 것 같아요.

<br />

- 전체 스토리를 건드리다보니 PR 규모가 꽤 큽니다. 😅
  - 이제 와서 놓고 보니 Layout / 기본 Component / 응용 Component 로 3등분해서 작업했으면 어땠을까 생각이 들기도 합니다. 
  - 근데 대부분 스토리 작업이기 때문에 (비지니스 로직이 아니니) 배포된 스토리북이나 **Chromatic** 으로 변경된 점을 확인해주시면 감사하겠습니다. 
  - 특히 Description으로 적은 부분에 대한 많은 수정, 코멘트 부탁드립니다. 🙏