### PR TITLE
fix: Thumb 위치 수정

### DIFF
--- a/src/components/RangeSelector/index.tsx
+++ b/src/components/RangeSelector/index.tsx
@@ -167,7 +167,7 @@ const Slider = () => {
     const thumbPos = setSliderPos(trackWidth, max, min, value, offset);
     const filledTrackPos = setSliderPos(trackWidth, max, min, value);
 
-    thumbRef.current.style.left = `${left + thumbPos}px`;
+    thumbRef.current.style.left = `${thumbPos}px`;
     trackRef.current.style.setProperty('--filled', `${filledTrackPos}px`);
   }, []);
 


### PR DESCRIPTION
## 🤠 개요

- #91 

## 💫 설명

- 기존에 Thumb의 위치가 **'Track의 왼쪽 좌표 + 계산된 Thumb 위치'** 로 계산되었습니다. 

- 위 수식에서 'Track의 왼쪽 좌표' 항이 정확한 렌더링을 방해하는 것으로 파악하여 삭제합니다. (더하지 않아도 되는 것으로 확인했습니다)

## 📷 스크린샷 (Optional)

# 🥳

<img width="1068" src="https://user-images.githubusercontent.com/31645195/229278021-ca0dd04b-7735-4b15-bfe1-78d9f633f3f8.png">
