### PR TITLE
Feat/drawer: Drawer 컴포넌트 구현

### DIFF
--- a/src/components/@common/CdsProvider/index.tsx
+++ b/src/components/@common/CdsProvider/index.tsx
@@ -1,5 +1,5 @@
 import Global from '@components-common/Global';
-import { PORTAL_TOAST_ROOT_ID } from '@constants/portal';
+import { DRAWER_PORTAL_ROOT_ID, TOAST_PORTAL_ROOT_ID } from '@constants/portal';
 import { ThemeProvider } from '@emotion/react';
 import { ReactNode } from 'react';
 
@@ -15,7 +15,8 @@ const CdsProvider = ({ children }: CdsProviderProps) => {
       <Global />
       <ThemeProvider theme={theme}>
         {children}
-        <div id={PORTAL_TOAST_ROOT_ID}></div>
+        <div id={DRAWER_PORTAL_ROOT_ID}></div>
+        <div id={TOAST_PORTAL_ROOT_ID}></div>
       </ThemeProvider>
     </>
   );

--- a/src/components/@common/Portal/index.tsx
+++ b/src/components/@common/Portal/index.tsx
@@ -1,12 +1,14 @@
+import { SerializedStyles } from '@emotion/react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
   id: string;
   children: ReactNode;
+  style?: SerializedStyles;
 }
 
-const Portal = ({ id, children }: PortalProps) => {
+const Portal = ({ id, children, style }: PortalProps) => {
   const ref = useRef<Element | null>();
   const [mounted, setMounted] = useState<boolean>(false);
 
@@ -15,6 +17,11 @@ const Portal = ({ id, children }: PortalProps) => {
     const portalRoot = document.getElementById(id);
     ref.current = portalRoot;
   }, []);
+
+  useEffect(() => {
+    if (!ref.current || !style) return;
+    ref.current.setAttribute('style', style.styles);
+  }, [style]);
 
   if (ref.current && mounted) {
     return createPortal(children, ref.current);

--- a/src/components/@common/Portal/index.tsx
+++ b/src/components/@common/Portal/index.tsx
@@ -1,12 +1,15 @@
+import { Theme } from '@components-common/CdsProvider/theme';
+import { Interpolation } from '@emotion/react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
   id: string;
   children: ReactNode;
+  style?: Interpolation<Theme>;
 }
 
-const Portal = ({ id, children }: PortalProps) => {
+const Portal = ({ id, children, style }: PortalProps) => {
   const ref = useRef<Element | null>();
   const [mounted, setMounted] = useState<boolean>(false);
 
@@ -15,6 +18,12 @@ const Portal = ({ id, children }: PortalProps) => {
     const portalRoot = document.getElementById(id);
     ref.current = portalRoot;
   }, []);
+
+  useEffect(() => {
+    if (!ref.current || !style) return;
+
+    ref.current.setAttribute('style', style.toString());
+  }, [style]);
 
   if (ref.current && mounted) {
     return createPortal(children, ref.current);

--- a/src/components/@common/Portal/index.tsx
+++ b/src/components/@common/Portal/index.tsx
@@ -1,15 +1,12 @@
-import { Theme } from '@components-common/CdsProvider/theme';
-import { Interpolation } from '@emotion/react';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 interface PortalProps {
   id: string;
   children: ReactNode;
-  style?: Interpolation<Theme>;
 }
 
-const Portal = ({ id, children, style }: PortalProps) => {
+const Portal = ({ id, children }: PortalProps) => {
   const ref = useRef<Element | null>();
   const [mounted, setMounted] = useState<boolean>(false);
 
@@ -18,12 +15,6 @@ const Portal = ({ id, children, style }: PortalProps) => {
     const portalRoot = document.getElementById(id);
     ref.current = portalRoot;
   }, []);
-
-  useEffect(() => {
-    if (!ref.current || !style) return;
-
-    ref.current.setAttribute('style', style.toString());
-  }, [style]);
 
   if (ref.current && mounted) {
     return createPortal(children, ref.current);

--- a/src/components/@layout/MobileContainer/index.tsx
+++ b/src/components/@layout/MobileContainer/index.tsx
@@ -1,0 +1,30 @@
+import { css } from '@emotion/react';
+import { ReactNode } from 'react';
+
+const MobileContainer = ({ children }: { children: ReactNode }) => {
+  const containerStyle = css`
+    position: relative;
+    width: min(100vw, 375px);
+    height: 100vh;
+
+    overflow: hidden;
+    margin: auto;
+  `;
+
+  const scrollableStyle = css`
+    height: 100vh;
+    overflow-y: scroll;
+
+    ::-webkit-scrollbar {
+      width: 0;
+    }
+  `;
+
+  return (
+    <div css={containerStyle}>
+      <div css={scrollableStyle}>{children}</div>
+    </div>
+  );
+};
+
+export default MobileContainer;

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -21,7 +21,7 @@ export default {
         component:
           '메뉴 리스트, 옵션 선택 양식 등 다양한 요소가 들어갈 수 있습니다.' +
           '\n\n컴포넌트 특성 상 스타일이 상위 요소에 영향을 받습니다.' +
-          '\n- `<Drawer />`가 차지할 영역을 결정하는 요소에 `position: relative`를 설정하고, HTML id를 `containerId` props로 전달해 커스텀이 가능합니다.' +
+          '\n- `<Drawer />`가 차지할 영역을 결정하는 요소에 CSS `position: relative; overflow: hidden;`을 설정하고, HTML id를 `containerId` props로 전달해 커스텀이 가능합니다.' +
           '\n- 기본값은 CDS에서 제공하는 Portal의 id입니다. `<CdsProvider />` 상위에 컨테이너를 감싸 스타일을 조정할 수도 있습니다. 용례는 Mobile 스토리를 참고하세요.',
       },
     },
@@ -139,6 +139,7 @@ CustomContainer.args = {
 
 const CustomDiv = styled.div`
   position: relative;
+  overflow: hidden;
   width: 300px;
   height: 300px;
 `;

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -1,0 +1,114 @@
+import Badge from '@components/Badge';
+import Button from '@components/Button';
+import CdsProvider from '@components-common/CdsProvider';
+import List from '@components-layout/List';
+import MobileContainer from '@components-layout/MobileContainer';
+import { css } from '@emotion/react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Drawer from '.';
+
+export default {
+  title: 'Design System/Components/Drawer',
+  component: Drawer,
+  parameters: {
+    layout: 'fullscreen',
+    componentSubtitle:
+      'Drawer는 감춰진 컨텐츠 영역이 트리거 동작에 슬라이딩 애니메이션과 함께 드러나고, dimmer 영역을 클릭해 닫을 수 있는 컴포넌트입니다.',
+    docs: {
+      description: {
+        component:
+          '- 메뉴 리스트, 옵션 선택 양식 등 다양한 요소가 들어갈 수 있습니다.' +
+          '\n- 컴포넌트 특성 상 스타일이 컨테이너와 결합되어 있습니다. 반응형을 고려해 개발한다면 Mobile 스토리를 참고해주세요.',
+      },
+    },
+  },
+  argTypes: {
+    label: {
+      description: 'Drawer 역할을 설명합니다.',
+    },
+    position: {
+      description: 'Panel 위치를 설정합니다.',
+      table: {
+        type: {
+          name: 'string',
+          required: false,
+        },
+        defaultValue: {
+          summary: '"left"',
+        },
+      },
+    },
+  },
+} as ComponentMeta<typeof Drawer>;
+
+const Template: ComponentStory<typeof Drawer> = (args) => {
+  return (
+    <Drawer {...args}>
+      <Drawer.Trigger>
+        <Button text="서랍을 열어요" />
+      </Drawer.Trigger>
+      <Drawer.Panel>
+        <List css={liStyle}>
+          <li>
+            <Badge>1</Badge>
+          </li>
+          <li>
+            <Badge>2</Badge>
+          </li>
+
+          <li>
+            <Badge>3</Badge>
+          </li>
+        </List>
+      </Drawer.Panel>
+    </Drawer>
+  );
+};
+const liStyle = css`
+  & > li {
+    width: 150px;
+    display: flex;
+    justify-content: center;
+  }
+`;
+
+export const Default = Template.bind({});
+Default.args = {
+  label: '옵션 메뉴',
+};
+Default.parameters = {
+  docs: {
+    storyDescription: 'Trigger 요소를 누르면 Panel이 열립니다.',
+  },
+};
+
+export const Bottom = Template.bind({});
+Bottom.args = {
+  label: '옵션 메뉴',
+  position: 'bottom',
+};
+Bottom.parameters = {
+  docs: {
+    storyDescription: 'position props를 통해 방향을 설정할 수 있습니다.',
+  },
+};
+
+export const Mobile = Template.bind({});
+Mobile.args = {
+  label: '옵션 메뉴',
+  position: 'bottom',
+};
+Mobile.parameters = {
+  docs: {
+    storyDescription:
+      'Show Code 예시처럼 반응형 컨테이너를 CdsProvider 부모 컴포넌트로 두는 것을 권장합니다.',
+  },
+};
+Mobile.decorators = [
+  (Story) => (
+    <MobileContainer>
+      <CdsProvider>{Story()}</CdsProvider>
+    </MobileContainer>
+  ),
+];

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -1,11 +1,10 @@
 import Badge from '@components/Badge';
 import Button from '@components/Button';
-import CdsProvider from '@components-common/CdsProvider';
 import List from '@components-layout/List';
-import MobileContainer from '@components-layout/MobileContainer';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ChildrenProps } from '@util-types/ChildrenProps';
 
 import Drawer from '.';
 
@@ -20,21 +19,25 @@ export default {
       description: {
         component:
           '메뉴 리스트, 옵션 선택 양식 등 다양한 요소가 들어갈 수 있습니다.' +
-          '\n\n컴포넌트 특성 상 스타일이 상위 요소에 영향을 받습니다.' +
-          '\n- `<Drawer />`가 차지할 영역을 결정하는 요소에 CSS `position: relative; overflow: hidden;`을 설정하고, HTML id를 `containerId` props로 전달해 커스텀이 가능합니다.' +
-          '\n- 기본값은 CDS에서 제공하는 Portal의 id입니다. `<CdsProvider />` 상위에 컨테이너를 감싸 스타일을 조정할 수도 있습니다. 용례는 Mobile 스토리를 참고하세요.',
+          '\n\n화면 전체 영역을 덮는 스타일을 기본으로 가집니다. 이외의 스타일링을 원한다면 Custom Parent, Mobile 스토리를 참고합니다.',
       },
     },
   },
   argTypes: {
     label: {
       description: 'Drawer 역할을 설명합니다.',
+      table: {
+        type: {
+          summary: 'string',
+          required: true,
+        },
+      },
     },
     position: {
       description: 'Panel 위치를 설정합니다.',
       table: {
         type: {
-          name: 'string',
+          summary: '"left" | "bottom"',
           required: false,
         },
         defaultValue: {
@@ -43,10 +46,10 @@ export default {
       },
     },
     containerId: {
-      description: '서랍 컨텐츠 상위 요소의 id를 전달합니다.',
+      description: '실제 DOM 상 Panel 부모가 될 요소의 HTML id를 전달합니다.',
       table: {
         type: {
-          name: 'string',
+          summary: 'string',
           required: false,
         },
         defaultValue: {
@@ -98,50 +101,52 @@ Bottom.parameters = {
   },
 };
 
+export const CustomParent = Template.bind({});
+CustomParent.args = {
+  label: '옵션 메뉴',
+  position: 'bottom',
+  containerId: 'custom-story-container',
+};
+CustomParent.decorators = [
+  (Story) => (
+    <CustomContainer id="custom-story-container">{Story()}</CustomContainer>
+  ),
+];
+CustomParent.parameters = {
+  docs: {
+    storyDescription:
+      '`<Drawer />`가 차지할 영역을 결정하는 요소의 HTML id를 `containerId` props로 전달해 스타일 커스텀이 가능합니다. 이 경우 해당 요소에 CSS `position: relative; overflow: hidden;` 스타일이 적용됩니다.',
+  },
+};
+
 export const Mobile = Template.bind({});
 Mobile.args = {
   label: '옵션 메뉴',
   position: 'bottom',
-};
-Mobile.parameters = {
-  docs: {
-    storyDescription:
-      'Show Code 예시처럼 반응형 컨테이너를 CdsProvider 부모 컴포넌트로 두고 사용할 수 있습니다.',
-  },
+  containerId: 'mobile-story-container',
 };
 Mobile.decorators = [
   (Story) => (
-    <MobileContainer>
-      <CdsProvider>{Story()}</CdsProvider>
-    </MobileContainer>
+    <MobileContainer id="mobile-story-container">{Story()}</MobileContainer>
   ),
 ];
-
-export const CustomContainer: ComponentStory<typeof Drawer> = (args) => {
-  return (
-    <CustomDiv id="custom-container">
-      <Drawer {...args}>
-        <Drawer.Trigger>
-          <Button text="서랍을 열어요" />
-        </Drawer.Trigger>
-        <Drawer.Panel>
-          <Panel />
-        </Drawer.Panel>
-      </Drawer>
-    </CustomDiv>
-  );
+Mobile.parameters = {
+  docs: {
+    storyDescription: `containerId 기본값은 \`<CdsProvider />\` 내 Portal id입니다. \`containerId\`를 전달하지 않아도 상위에 반응형 컨테이너를 감싸 Portal 영역을 조정할 수도 있습니다.
+      \n스토리를 박스 내부에서 표현하기 위해 실제 사용법과 다르게 작성되었습니다. 예시 코드는 아래 블럭을 참고하세요.
+      
+      const App = () => {
+          return (
+              <MobileContainer>
+                  <CdsProvider>
+                      // ... your components
+                  </CdsProvider>
+              </MobileContainer>
+          );
+      };
+      `,
+  },
 };
-CustomContainer.args = {
-  label: '옵션 메뉴',
-  containerId: 'custom-container',
-};
-
-const CustomDiv = styled.div`
-  position: relative;
-  overflow: hidden;
-  width: 300px;
-  height: 300px;
-`;
 
 const Panel = () => {
   return (
@@ -156,5 +161,28 @@ const Panel = () => {
         <Badge>미지근한 스터디</Badge>
       </li>
     </List>
+  );
+};
+
+const CustomContainer = styled.div`
+  width: 100%;
+  height: 200px;
+`;
+
+const MobileContainer = ({ id, children }: { id: string } & ChildrenProps) => {
+  return (
+    <div
+      id={id}
+      css={css`
+        position: relative;
+        width: min(100vw, 375px);
+        height: 812px;
+
+        overflow: hidden;
+        margin: auto;
+      `}
+    >
+      {children}
+    </div>
   );
 };

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -9,7 +9,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Drawer from '.';
 
 export default {
-  title: 'Design System/Components/Drawer',
+  title: 'Components/Drawer',
   component: Drawer,
   parameters: {
     layout: 'fullscreen',

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -119,7 +119,7 @@ Mobile.decorators = [
 
 export const CustomContainer: ComponentStory<typeof Drawer> = (args) => {
   return (
-    <>
+    <CustomDiv id="custom-container">
       <Drawer {...args}>
         <Drawer.Trigger>
           <Button text="서랍을 열어요" />
@@ -128,8 +128,7 @@ export const CustomContainer: ComponentStory<typeof Drawer> = (args) => {
           <Panel />
         </Drawer.Panel>
       </Drawer>
-      <CustomDiv id="custom-container"></CustomDiv>
-    </>
+    </CustomDiv>
   );
 };
 CustomContainer.args = {

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -2,7 +2,6 @@ import Badge from '@components/Badge';
 import Button from '@components/Button';
 import List from '@components-layout/List';
 import { css } from '@emotion/react';
-import styled from '@emotion/styled';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ChildrenProps } from '@util-types/ChildrenProps';
 
@@ -67,7 +66,7 @@ const Template: ComponentStory<typeof Drawer> = (args) => {
         <Button text="서랍을 열어요" />
       </Drawer.Trigger>
       <Drawer.Panel>
-        <Panel />
+        <StudyList />
       </Drawer.Panel>
     </Drawer>
   );
@@ -148,7 +147,7 @@ Mobile.parameters = {
   },
 };
 
-const Panel = () => {
+const StudyList = () => {
   return (
     <List css={liStyle}>
       <li>
@@ -164,10 +163,17 @@ const Panel = () => {
   );
 };
 
-const CustomContainer = styled.div`
-  width: 100%;
-  height: 200px;
-`;
+const CustomContainer = ({ id, children }: { id: string } & ChildrenProps) => (
+  <div
+    id={id}
+    css={css`
+      width: 100%;
+      height: 200px;
+    `}
+  >
+    {children}
+  </div>
+);
 
 const MobileContainer = ({ id, children }: { id: string } & ChildrenProps) => {
   return (

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -4,6 +4,7 @@ import CdsProvider from '@components-common/CdsProvider';
 import List from '@components-layout/List';
 import MobileContainer from '@components-layout/MobileContainer';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 
 import Drawer from '.';
@@ -18,8 +19,10 @@ export default {
     docs: {
       description: {
         component:
-          '- 메뉴 리스트, 옵션 선택 양식 등 다양한 요소가 들어갈 수 있습니다.' +
-          '\n- 컴포넌트 특성 상 스타일이 컨테이너와 결합되어 있습니다. 반응형을 고려해 개발한다면 Mobile 스토리를 참고해주세요.',
+          '메뉴 리스트, 옵션 선택 양식 등 다양한 요소가 들어갈 수 있습니다.' +
+          '\n\n컴포넌트 특성 상 스타일이 상위 요소에 영향을 받습니다.' +
+          '\n- `<Drawer />`가 차지할 영역을 결정하는 요소에 `position: relative`를 설정하고, HTML id를 `containerId` props로 전달해 커스텀이 가능합니다.' +
+          '\n- 기본값은 CDS에서 제공하는 Portal의 id입니다. `<CdsProvider />` 상위에 컨테이너를 감싸 스타일을 조정할 수도 있습니다. 용례는 Mobile 스토리를 참고하세요.',
       },
     },
   },
@@ -39,6 +42,18 @@ export default {
         },
       },
     },
+    containerId: {
+      description: '서랍 컨텐츠 상위 요소의 id를 전달합니다.',
+      table: {
+        type: {
+          name: 'string',
+          required: false,
+        },
+        defaultValue: {
+          summary: 'DRAWER_PORTAL_ROOT_ID',
+        },
+      },
+    },
   },
 } as ComponentMeta<typeof Drawer>;
 
@@ -49,18 +64,7 @@ const Template: ComponentStory<typeof Drawer> = (args) => {
         <Button text="서랍을 열어요" />
       </Drawer.Trigger>
       <Drawer.Panel>
-        <List css={liStyle}>
-          <li>
-            <Badge>1</Badge>
-          </li>
-          <li>
-            <Badge>2</Badge>
-          </li>
-
-          <li>
-            <Badge>3</Badge>
-          </li>
-        </List>
+        <Panel />
       </Drawer.Panel>
     </Drawer>
   );
@@ -102,7 +106,7 @@ Mobile.args = {
 Mobile.parameters = {
   docs: {
     storyDescription:
-      'Show Code 예시처럼 반응형 컨테이너를 CdsProvider 부모 컴포넌트로 두는 것을 권장합니다.',
+      'Show Code 예시처럼 반응형 컨테이너를 CdsProvider 부모 컴포넌트로 두고 사용할 수 있습니다.',
   },
 };
 Mobile.decorators = [
@@ -112,3 +116,45 @@ Mobile.decorators = [
     </MobileContainer>
   ),
 ];
+
+export const CustomContainer: ComponentStory<typeof Drawer> = (args) => {
+  return (
+    <>
+      <Drawer {...args}>
+        <Drawer.Trigger>
+          <Button text="서랍을 열어요" />
+        </Drawer.Trigger>
+        <Drawer.Panel>
+          <Panel />
+        </Drawer.Panel>
+      </Drawer>
+      <CustomDiv id="custom-container"></CustomDiv>
+    </>
+  );
+};
+CustomContainer.args = {
+  label: '옵션 메뉴',
+  containerId: 'custom-container',
+};
+
+const CustomDiv = styled.div`
+  position: relative;
+  width: 300px;
+  height: 300px;
+`;
+
+const Panel = () => {
+  return (
+    <List css={liStyle}>
+      <li>
+        <Badge>차가운 스터디</Badge>
+      </li>
+      <li>
+        <Badge>따뜻한 스터디</Badge>
+      </li>
+      <li>
+        <Badge>미지근한 스터디</Badge>
+      </li>
+    </List>
+  );
+};

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -53,13 +53,9 @@ const Trigger = ({ children }: ChildProps) => {
     const $drawer = drawerRef.current;
     if (!$drawer) return;
 
-    setIsOpen((prev) => {
-      if (!prev === true) {
-        $drawer.addEventListener('animationend', () => $drawer.focus(), {
-          once: true,
-        });
-      }
-      return !prev;
+    setIsOpen(true);
+    $drawer.addEventListener('animationend', () => $drawer.focus(), {
+      once: true,
     });
   };
 
@@ -74,12 +70,13 @@ const Trigger = ({ children }: ChildProps) => {
     'aria-haspopup': 'true',
     'aria-expanded': !!isOpen,
     'aria-controls': `${label}-drawer`,
-    'aria-label': `${label} 서랍을 ${isOpen ? '닫는' : '여는'} 트리거`,
+    'aria-label': `${label} 서랍을 여는 트리거`,
     onClick: onOpen,
     onKeyDown,
     style: {
       cursor: 'pointer',
     },
+    tabIndex: isOpen ? -1 : 0,
   });
 };
 

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -32,7 +32,7 @@ interface DrawerContextInterface {
 }
 const DrawerContext = createContext<DrawerContextInterface | null>(null);
 
-const Drawer = ({ label, position = 'bottom', children }: DrawerProps) => {
+const Drawer = ({ label, position = 'left', children }: DrawerProps) => {
   const [isOpen, setIsOpen] = useState<boolean | null>(null);
 
   const drawerRef = useRef<HTMLUnknownElement>(null);

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -3,7 +3,12 @@ import { ENTER, SPACE } from '@constants/key';
 import { DRAWER_PORTAL_ROOT_ID } from '@constants/portal';
 import { css, useTheme } from '@emotion/react';
 import { ChildProps, ChildrenProps, SetState } from '@utils';
-import { KeyboardEventHandler, createContext, useState } from 'react';
+import {
+  KeyboardEventHandler,
+  cloneElement,
+  createContext,
+  useState,
+} from 'react';
 import useSafeContext from 'src/hooks/useSafeContext';
 
 import useDrawerStyle from './useDrawerStyle';
@@ -39,27 +44,20 @@ const Trigger = ({ children }: ChildProps) => {
   const { label, isOpen, setIsOpen } = useSafeContext(DrawerContext);
 
   const onKeyDown: KeyboardEventHandler = (e) => {
-    if ([SPACE, ENTER].includes(e.key)) setIsOpen((prev) => !prev);
+    if ([SPACE, ENTER].includes(e.key)) setIsOpen(true);
   };
 
-  const triggerStyle = css`
-    width: auto;
-    height: auto;
-    cursor: pointer;
-  `;
-
-  return (
-    <div
-      css={triggerStyle}
-      aria-haspopup={true}
-      aria-expanded={!!isOpen}
-      aria-controls={`${label}-drawer`}
-      onClick={() => setIsOpen((prev) => !prev)}
-      onKeyDown={onKeyDown}
-    >
-      {children}
-    </div>
-  );
+  return cloneElement(children, {
+    'aria-haspopup': 'true',
+    'aria-expanded': !!isOpen,
+    'aria-controls': `${label}-drawer`,
+    'aria-label': `${label} 서랍을 여는 트리거`,
+    onClick: () => setIsOpen(true),
+    onKeyDown,
+    style: {
+      cursor: 'pointer',
+    },
+  });
 };
 
 const Panel = ({ children }: ChildrenProps) => {

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -118,11 +118,12 @@ const Panel = ({ children }: ChildrenProps) => {
 
   const { color } = useTheme();
   const { black, offwhite } = color;
+  const isFixedDrawer = containerId === DRAWER_PORTAL_ROOT_ID;
 
-  const { drawerStyle } = useDrawerStyle(position, offwhite);
+  const { drawerStyle } = useDrawerStyle(position, offwhite, isFixedDrawer);
   const dimmerStyle = css`
-    ${isOpen ? '' : 'display: none;'}
-    position: absolute;
+    display: ${isOpen ? 'block' : 'none'};
+    position: ${isFixedDrawer ? 'fixed' : 'absolute'};
     top: 0;
     left: 0;
     width: 100%;
@@ -132,8 +133,15 @@ const Panel = ({ children }: ChildrenProps) => {
     opacity: 20%;
   `;
 
+  const portalStyle = isFixedDrawer
+    ? undefined
+    : css`
+        position: relative;
+        overflow: hidden;
+      `;
+
   return (
-    <Portal id={containerId}>
+    <Portal id={containerId} style={portalStyle}>
       <div
         css={dimmerStyle}
         aria-hidden={true}

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -73,7 +73,7 @@ const Panel = ({ children }: ChildrenProps) => {
   const { drawerStyle } = useDrawerStyle(position, offwhite);
   const dimmerStyle = css`
     ${isOpen ? '' : 'display: none;'}
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;
@@ -83,8 +83,13 @@ const Panel = ({ children }: ChildrenProps) => {
     opacity: 20%;
   `;
 
+  const portalStyle = css`
+    position: relative;
+    visibility: ${isOpen ? 'visible' : 'hidden'};
+  `;
+
   return (
-    <Portal id={DRAWER_PORTAL_ROOT_ID}>
+    <Portal id={DRAWER_PORTAL_ROOT_ID} style={portalStyle}>
       <div
         css={dimmerStyle}
         aria-hidden={true}

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -21,6 +21,7 @@ export type DrawerPosition = 'bottom' | 'left';
 type DrawerProps = {
   label: string;
   position?: DrawerPosition;
+  containerId?: string;
 } & ChildrenProps;
 
 interface DrawerContextInterface {
@@ -29,15 +30,28 @@ interface DrawerContextInterface {
   isOpen: boolean | null;
   setIsOpen: SetState<boolean | null>;
   drawerRef: RefObject<HTMLUnknownElement>;
+  containerId: string;
 }
 const DrawerContext = createContext<DrawerContextInterface | null>(null);
 
-const Drawer = ({ label, position = 'left', children }: DrawerProps) => {
+const Drawer = ({
+  label,
+  position = 'left',
+  containerId = DRAWER_PORTAL_ROOT_ID,
+  children,
+}: DrawerProps) => {
   const [isOpen, setIsOpen] = useState<boolean | null>(null);
 
   const drawerRef = useRef<HTMLUnknownElement>(null);
 
-  const providerValue = { label, position, isOpen, setIsOpen, drawerRef };
+  const providerValue = {
+    label,
+    position,
+    isOpen,
+    setIsOpen,
+    drawerRef,
+    containerId,
+  };
 
   return (
     <DrawerContext.Provider value={providerValue}>
@@ -81,7 +95,7 @@ const Trigger = ({ children }: ChildProps) => {
 };
 
 const Panel = ({ children }: ChildrenProps) => {
-  const { label, position, isOpen, setIsOpen, drawerRef } =
+  const { label, position, isOpen, setIsOpen, drawerRef, containerId } =
     useSafeContext(DrawerContext);
 
   const onKeyDown = (e: Event) => {
@@ -92,7 +106,7 @@ const Panel = ({ children }: ChildrenProps) => {
     }
   };
   useEffect(() => {
-    const $portal = document.querySelector(`#${DRAWER_PORTAL_ROOT_ID}`);
+    const $portal = document.querySelector(`#${containerId}`);
     if (!$portal) return;
 
     $portal.addEventListener('keydown', onKeyDown);
@@ -124,7 +138,7 @@ const Panel = ({ children }: ChildrenProps) => {
   `;
 
   return (
-    <Portal id={DRAWER_PORTAL_ROOT_ID} style={portalStyle}>
+    <Portal id={containerId} style={portalStyle}>
       <div
         css={dimmerStyle}
         aria-hidden={true}

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -55,7 +55,9 @@ const Trigger = ({ children }: ChildProps) => {
 
     setIsOpen((prev) => {
       if (!prev === true) {
-        setTimeout(() => $drawer.focus(), 600);
+        $drawer.addEventListener('animationend', () => $drawer.focus(), {
+          once: true,
+        });
       }
       return !prev;
     });
@@ -72,7 +74,7 @@ const Trigger = ({ children }: ChildProps) => {
     'aria-haspopup': 'true',
     'aria-expanded': !!isOpen,
     'aria-controls': `${label}-drawer`,
-    'aria-label': `${label} 서랍을 여는 트리거`,
+    'aria-label': `${label} 서랍을 ${isOpen ? '닫는' : '여는'} 트리거`,
     onClick: onOpen,
     onKeyDown,
     style: {

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -164,6 +164,8 @@ const Panel = ({ children }: ChildrenProps) => {
 };
 
 Drawer.Trigger = Trigger;
+Trigger.displayName = 'Drawer.Trigger';
 Drawer.Panel = Panel;
+Panel.displayName = 'Drawer.Panel';
 
 export default Drawer;

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -132,13 +132,8 @@ const Panel = ({ children }: ChildrenProps) => {
     opacity: 20%;
   `;
 
-  const portalStyle = css`
-    position: relative;
-    visibility: ${isOpen ? 'visible' : 'hidden'};
-  `;
-
   return (
-    <Portal id={containerId} style={portalStyle}>
+    <Portal id={containerId}>
       <div
         css={dimmerStyle}
         aria-hidden={true}

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -53,12 +53,19 @@ const Trigger = ({ children }: ChildProps) => {
     const $drawer = drawerRef.current;
     if (!$drawer) return;
 
-    setIsOpen(true);
-    setTimeout(() => $drawer.focus(), 600);
+    setIsOpen((prev) => {
+      if (!prev === true) {
+        setTimeout(() => $drawer.focus(), 600);
+      }
+      return !prev;
+    });
   };
 
   const onKeyDown: KeyboardEventHandler = (e) => {
-    if ([SPACE, ENTER].includes(e.key)) onOpen();
+    if ([SPACE, ENTER].includes(e.key)) {
+      e.preventDefault();
+      onOpen();
+    }
   };
 
   return cloneElement(children, {

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -2,6 +2,7 @@ import Portal from '@components-common/Portal';
 import { ENTER, ESC, SPACE } from '@constants/key';
 import { DRAWER_PORTAL_ROOT_ID } from '@constants/portal';
 import { css, useTheme } from '@emotion/react';
+import { dimmerStyle as commonDimmerStyle } from '@styles/dimmed';
 import { ChildProps, ChildrenProps, SetState } from '@utils';
 import {
   KeyboardEventHandler,
@@ -117,20 +118,14 @@ const Panel = ({ children }: ChildrenProps) => {
   });
 
   const { color } = useTheme();
-  const { black, offwhite } = color;
+  const { offwhite } = color;
   const isFixedDrawer = containerId === DRAWER_PORTAL_ROOT_ID;
 
   const { drawerStyle } = useDrawerStyle(position, offwhite, isFixedDrawer);
   const dimmerStyle = css`
     display: ${isOpen ? 'block' : 'none'};
-    position: ${isFixedDrawer ? 'fixed' : 'absolute'};
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    ${commonDimmerStyle(isFixedDrawer ? 'fixed' : 'absolute', color)}
     overflow-y: hidden;
-    background-color: ${black};
-    opacity: 20%;
   `;
 
   const portalStyle = isFixedDrawer

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -1,0 +1,110 @@
+import Portal from '@components-common/Portal';
+import { ENTER, SPACE } from '@constants/key';
+import { DRAWER_PORTAL_ROOT_ID } from '@constants/portal';
+import { css, useTheme } from '@emotion/react';
+import { ChildProps, ChildrenProps, SetState } from '@utils';
+import { KeyboardEventHandler, createContext, useState } from 'react';
+import useSafeContext from 'src/hooks/useSafeContext';
+
+import useDrawerStyle from './useDrawerStyle';
+
+export type DrawerPosition = 'bottom' | 'left';
+
+type DrawerProps = {
+  label: string;
+  position?: DrawerPosition;
+} & ChildrenProps;
+
+interface DrawerContextInterface {
+  label: string;
+  position: DrawerPosition;
+  isOpen: boolean | null;
+  setIsOpen: SetState<boolean | null>;
+}
+const DrawerContext = createContext<DrawerContextInterface | null>(null);
+
+const Drawer = ({ label, position = 'bottom', children }: DrawerProps) => {
+  const [isOpen, setIsOpen] = useState<boolean | null>(null);
+
+  const providerValue = { label, position, isOpen, setIsOpen };
+
+  return (
+    <DrawerContext.Provider value={providerValue}>
+      {children}
+    </DrawerContext.Provider>
+  );
+};
+
+const Trigger = ({ children }: ChildProps) => {
+  const { label, isOpen, setIsOpen } = useSafeContext(DrawerContext);
+
+  const onKeyDown: KeyboardEventHandler = (e) => {
+    if ([SPACE, ENTER].includes(e.key)) setIsOpen((prev) => !prev);
+  };
+
+  const triggerStyle = css`
+    width: auto;
+    height: auto;
+    cursor: pointer;
+  `;
+
+  return (
+    <div
+      css={triggerStyle}
+      aria-haspopup={true}
+      aria-expanded={!!isOpen}
+      aria-controls={`${label}-drawer`}
+      onClick={() => setIsOpen((prev) => !prev)}
+      onKeyDown={onKeyDown}
+    >
+      {children}
+    </div>
+  );
+};
+
+const Panel = ({ children }: ChildrenProps) => {
+  const { label, position, isOpen, setIsOpen } = useSafeContext(DrawerContext);
+
+  // TODO: close with Esc key
+
+  const { color } = useTheme();
+  const { black, offwhite } = color;
+
+  const { drawerStyle } = useDrawerStyle(position, offwhite);
+  const dimmerStyle = css`
+    ${isOpen ? '' : 'display: none;'}
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow-y: hidden;
+    background-color: ${black};
+    opacity: 20%;
+  `;
+
+  return (
+    <Portal id={DRAWER_PORTAL_ROOT_ID}>
+      <div
+        css={dimmerStyle}
+        aria-hidden={true}
+        aria-controls={`${label}-drawer`}
+        onClick={() => setIsOpen(false)}
+      ></div>
+      <aside
+        id={`${label}-drawer`}
+        css={drawerStyle}
+        // eslint-disable-next-line no-nested-ternary
+        className={isOpen === null ? 'initial' : isOpen ? 'open' : 'close'}
+        aria-hidden={!isOpen}
+      >
+        {children}
+      </aside>
+    </Portal>
+  );
+};
+
+Drawer.Trigger = Trigger;
+Drawer.Panel = Panel;
+
+export default Drawer;

--- a/src/components/Drawer/useDrawerStyle.tsx
+++ b/src/components/Drawer/useDrawerStyle.tsx
@@ -33,6 +33,7 @@ const useDrawerStyle = (
     ${STYLE[position]}
     transform: ${TRANSLATE[position]};
     background-color: ${backgroundColor};
+    padding: 12px;
 
     &.open {
       animation: ${slideIn} 0.5s;

--- a/src/components/Drawer/useDrawerStyle.tsx
+++ b/src/components/Drawer/useDrawerStyle.tsx
@@ -51,7 +51,7 @@ const useDrawerStyle = (
 export default useDrawerStyle;
 
 const STYLE: Record<DrawerPosition, string> = {
-  bottom: 'bottom: 0; width: 100%;',
+  bottom: 'bottom: 0; left: 0; width: 100%;',
   left: 'top: 0; left: 0; height: 100%;',
 };
 

--- a/src/components/Drawer/useDrawerStyle.tsx
+++ b/src/components/Drawer/useDrawerStyle.tsx
@@ -1,0 +1,60 @@
+import { css, keyframes } from '@emotion/react';
+import { CSSProperties } from 'react';
+
+import type { DrawerPosition } from '.';
+
+const useDrawerStyle = (
+  position: DrawerPosition,
+  backgroundColor: CSSProperties['backgroundColor'],
+) => {
+  const slideIn = keyframes`
+      from {
+        transform: ${TRANSLATE[position]};
+      }
+  
+      to {
+        transform: translateX(0) translateY(0);
+      }
+    `;
+
+  const slideOut = keyframes`
+      from {
+        transform: translateX(0) translateY(0);
+      }
+  
+      to {
+        transform: ${TRANSLATE[position]};
+      }
+  `;
+
+  const drawerStyle = css`
+    position: absolute;
+    ${STYLE[position]}
+    transform: ${TRANSLATE[position]};
+    background-color: ${backgroundColor};
+
+    &.open {
+      animation: ${slideIn} 0.5s;
+      transform: translateX(0) translateY(0);
+    }
+
+    &.close {
+      animation: ${slideOut} 0.5s;
+      transform: ${TRANSLATE[position]};
+    }
+  `;
+
+  return { drawerStyle };
+};
+
+export default useDrawerStyle;
+
+const STYLE: Record<DrawerPosition, string> = {
+  bottom: 'bottom: 0; width: 100%;',
+  left: 'top: 0; left: 0; height: 100%;',
+};
+
+const TRANSLATE: Record<DrawerPosition, CSSProperties['transform']> = {
+  bottom: 'translateY(100%)',
+  left: 'translateX(-100%)',
+};

--- a/src/components/Drawer/useDrawerStyle.tsx
+++ b/src/components/Drawer/useDrawerStyle.tsx
@@ -6,6 +6,7 @@ import type { DrawerPosition } from '.';
 const useDrawerStyle = (
   position: DrawerPosition,
   backgroundColor: CSSProperties['backgroundColor'],
+  isFixed: boolean,
 ) => {
   const slideIn = keyframes`
       from {
@@ -28,7 +29,7 @@ const useDrawerStyle = (
   `;
 
   const drawerStyle = css`
-    position: absolute;
+    position: ${isFixed ? 'fixed' : 'absolute'};
     ${STYLE[position]}
     transform: ${TRANSLATE[position]};
     background-color: ${backgroundColor};

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -2,6 +2,7 @@ import Container from '@components-layout/Container';
 import { ENTER, SPACE } from '@constants/key';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { ChildProps } from '@util-types/ChildProps';
 import { ChildrenProps } from '@util-types/ChildrenProps';
 import {
   cloneElement,
@@ -11,7 +12,6 @@ import {
   KeyboardEventHandler,
   MouseEvent as ReactMouseEvent,
   MouseEventHandler,
-  ReactElement,
   SetStateAction,
   useEffect,
   useRef,
@@ -82,7 +82,7 @@ const Dropdown = ({
   );
 };
 
-const Trigger = ({ children }: { children: ReactElement }) => {
+const Trigger = ({ children }: ChildProps) => {
   const { isOpen, setIsOpen, label, setTriggerSize } =
     useSafeContext(DropdownContext);
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -5,6 +5,7 @@ import Flexbox from '@components-layout/Flexbox';
 import { MODAL_PORTAL_ROOT_ID } from '@constants/portal';
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+import { dimmerStyle } from '@styles/dimmed';
 import { ChildrenProps } from '@util-types/ChildrenProps';
 import { DefaultPropsWithChildren } from '@utils/types/DefaultPropsWithChildren';
 import { MouseEventHandler, createContext } from 'react';
@@ -94,13 +95,8 @@ const ModalBox = styled.div`
 `;
 
 const Dimmed = styled.div`
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  z-index: 998;
   display: flex;
-  opacity: 0.4;
-  background-color: ${({ theme }) => theme.color.black};
+  ${({ theme }) => dimmerStyle('fixed', theme.color)}
 `;
 
 const Button = styled.button`

--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -1,11 +1,11 @@
 import Portal from '@components-common/Portal';
-import { PORTAL_TOAST_ROOT_ID } from '@constants/portal';
+import { TOAST_PORTAL_ROOT_ID } from '@constants/portal';
 
 import ToastOrigin, { ToastProps } from './ToastCore';
 
 const Toast = (props: ToastProps) => {
   return (
-    <Portal id={PORTAL_TOAST_ROOT_ID}>
+    <Portal id={TOAST_PORTAL_ROOT_ID}>
       <ToastOrigin {...props} />
     </Portal>
   );

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -17,3 +17,5 @@ export const COLOR = {
   white: '#FEFEFE',
   offwhite: '#FCFCFC',
 } as const;
+
+export type Color = typeof COLOR;

--- a/src/constants/portal.ts
+++ b/src/constants/portal.ts
@@ -1,1 +1,2 @@
-export const PORTAL_TOAST_ROOT_ID = 'cds-portal-toast-root';
+export const DRAWER_PORTAL_ROOT_ID = 'cds-portal-root-drawer';
+export const TOAST_PORTAL_ROOT_ID = 'cds-portal-root-toast';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,11 @@ export { default as Center } from '@components-layout/Center';
 export { default as Container } from '@components-layout/Container';
 export { default as Flexbox } from '@components-layout/Flexbox';
 export { default as List } from '@components-layout/List';
+export { default as MobileContainer } from '@components-layout/MobileContainer';
 
 export { default as Badge } from '@components/Badge';
 export { default as Button } from '@components/Button';
+export { default as Drawer } from '@components/Drawer';
 export { default as Dropdown } from '@components/Dropdown';
 export { default as Icon } from '@components/Icon';
 export { default as Input } from '@components/Input';

--- a/src/styles/dimmed.ts
+++ b/src/styles/dimmed.ts
@@ -1,0 +1,22 @@
+import { Color } from '@constants/color';
+import { css } from '@emotion/react';
+import { CSSProperties } from 'react';
+
+/**
+ * @param {CSSProperties['position']} position
+ * @param {Color} {black}
+ * @returns {SerializedStyles}
+ */
+export const dimmerStyle = (
+  position: CSSProperties['position'],
+  { black }: Color,
+) => css`
+  position: ${position};
+  top: 0;
+  left: 0;
+  z-index: 998;
+  width: 100%;
+  height: 100%;
+  opacity: 0.4;
+  background-color: ${black};
+`;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './pixelToRem';
 
+export type { ChildProps } from './types/ChildProps';
 export type { ChildrenProps } from './types/ChildrenProps';
 export type { DefaultProps } from './types/DefaultProps';
 export type { DefaultPropsWithChildren } from './types/DefaultPropsWithChildren';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export type { ChildrenProps } from './types/ChildrenProps';
 export type { DefaultProps } from './types/DefaultProps';
 export type { DefaultPropsWithChildren } from './types/DefaultPropsWithChildren';
 export type { FlexContainerProps } from './types/FlexContainerProps';
+export type { SetState } from './types/SetState';

--- a/src/utils/types/ChildProps.ts
+++ b/src/utils/types/ChildProps.ts
@@ -1,0 +1,3 @@
+import { ReactElement } from 'react';
+
+export type ChildProps = { children: ReactElement };

--- a/src/utils/types/SetState.ts
+++ b/src/utils/types/SetState.ts
@@ -1,0 +1,3 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export type SetState<T> = Dispatch<SetStateAction<T>>;

--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -8,6 +8,7 @@
       "@constants/*": ["./src/constants/*"],
       "@styles/*": ["./src/styles/*"],
       "@util-types/*": ["./src/utils/types/*"],
+      "@utils": ["./src/utils"],
       "@utils/*": ["./src/utils/*"]
     }
   }


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #86 

- Drawer 컴포넌트를 구현합니다. 감춰진 컨텐츠 영역이 트리거 동작에 슬라이딩 애니메이션과 함께 드러나고, dimmer 영역을 클릭해 닫을 수 있는 컴포넌트입니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->

- 접근성 라벨과 ID에 사용될 label, 위치를 결정하는 position, 스타일 커스텀을 원하는 경우에 사용할 수 있는 containerId를 props로 가집니다.

- [Dropdown과 마찬가지의 이유](https://github.com/c-h-w-h/cds/pull/71#issue-1637603441)로 Trigger에는 cloneElement를 사용했습니다.

- 키보드 접근성은 닫힌 상태에서 트리거 요소로 서랍을 열고, 열려있는 상태에서 esc 키로 탈출할 수 있게 했습니다.

  - 서랍이 열리면 포커스가 패널로 이동합니다.

  - 열린 상태에서는 서랍 레이어 외의 요소와 상호작용 할 수 없습니다.

### 그 외 마이너한 변경들

- ChildProps, SetState 유틸리티 타입이 추가되었어요. (이제껏 불편하게 쓰다가 이제와서야..)

- PORTAL_ROOT_ID 상수가 여러 컴포넌트를 관리하다보니 prefix로 컴포넌트명이 오는게 읽기 편한 것 같아 수정했어요.

### TBD

- [x] Modal 컴포넌트와 dimmer 스타일 통일

- [ ] 서랍이 닫히는 경우의 권고사항인 트리거로 focus 이동
  까지 구현하려고 했는데, cloneElement를 적용해두어서 triggerRef를 관리하는게 까다로워 고민거리로 남겨놓습니다. (children이 forwardRef가 적용되지 않은 Function Component인 경우가 있어요. 지금 생각하기로는 interactive 요소의 중첩 또는 접근성 가이드 중 하나를 포기해야 할 것 같은데 포커스 이동보다 올바른 시맨틱이 우선이에요.)

- [ ] bottom drawer 핸들 구현

<details>
<summary>⭐️ 중요하고 피드백이 필요했지만 해결된 내용</summary>

<br />

(해결은 https://github.com/c-h-w-h/cds/pull/109#issuecomment-1518965976 참고)

### ⭐️ 중요하고 피드백이 필요해요

- 서랍 스타일은 불가피하게 상위 컨테이너에 의존도가 있어요. bottom일 때 width: 100%; left일 때 height: 100%;을 가지도록 했는데 Portal 상위에 컨테이너가 없다보니 bottom인 경우에 이런식으로 스타일링이 되더라고요.

    <img width="500" alt="image" src="https://user-images.githubusercontent.com/63814960/233756581-5a00da4d-d873-468f-a136-e1198f5a8d9e.png">

    - Portal 없이 position 속성만 사용할지 잠시 고민했는데 상위 요소 스타일링에 영향을 받는 문제가 해결되는게 아니고, 컨테이너 외의 상위 컴포넌트에 relative가 명시되어 있다든지.. 고려할 점이 더 많아서 기각했어요.

    - SCSS의 `@at-root` 문법도 요소별 클래스 네임으로 스타일을 관리하는 CSS-in-JS에서는 사용이 불가능해요.

- **상위 컨테이너 id를 props로 전달받도록하고 관련 내용과 스타일링 필수 속성, 용례를 스토리에 추가했어요.** 아래의 댓글과 작업 참고해주세요.

  - https://github.com/c-h-w-h/cds/pull/109#issuecomment-1518669452

  - [feat: containerId props 추가 및 스토리에 반영](https://github.com/c-h-w-h/cds/pull/109/commits/d538cda03c5020a4d7c229ebcc977d98651fc72e)

- 스토리와 추후 개발에 사용하기 위해 최대 width가 375px로 고정되는 `MobileContainer` 컴포넌트를 만들었어요.
    
  - `CdsProvider` 자체에 반응형 컨테이너를 넣는건 라이브러리 사용 자체에 제약이 생기기 때문에 기각했어요.
    
    <img width="500" alt="image" src="https://user-images.githubusercontent.com/63814960/233756863-6960e29a-8a34-4c2f-9826-7ba0156e2d3c.png">


- 모달이나 토스트도 포털을 사용하고 있기 때문에 똑같이 적용되는 내용이에요.

  - 데스크탑 뷰에서는 영역을 어떻게 써야하는지 같이 고민해봤어야 하는데 이런 이슈가 있다는걸 너무 늦게 깨달았어요.
    
  - 지금 방식이 괜찮은지 발생할 수 있는 이슈가 없는지 의견 주시고 !!! 사용하면서도 피드백 해봐요 🤓
</details>

## 📷 스크린샷

https://user-images.githubusercontent.com/63814960/233858113-86e6fcc5-9610-438e-b519-2863db6708ab.mov
