### PR TITLE
Feat/theme-color: Theme color 변경 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - [Documentation](#documentation)
 - [Contributors](#contributors) -->
 
-## Usage
+## Installation
 
 ```zsh
 npm install @chwh/cds
@@ -19,11 +19,15 @@ npm install @chwh/cds
 yarn add @chwh/cds
 ```
 
-<br />
+## Documentation
 
-⚠️ 사용을 위해 상위 컴포넌트를 `CdsProvider`로 감싸야 합니다.
+[Storybook 문서](https://640054c53834f08f15bbad68-gkurucdpms.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인해보세요.
 
-```jsx
+## Usage
+
+사용을 위해 상위 컴포넌트를 `CdsProvider`로 감싸야 합니다.
+
+```tsx
 const App = () => {
   return (
     <CdsProvider>
@@ -33,9 +37,30 @@ const App = () => {
 };
 ```
 
-## Documentation
+아래 인터페이스 중 일부를 재정의한 객체를 `themeColor` props로 전달해 테마 컬러를 변경할 수 있습니다.
 
-[Storybook 문서](https://640054c53834f08f15bbad68-gkurucdpms.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인해보세요.
+```tsx
+type ColorSet = {
+  primary: Property.Color;
+  primaryLight: Property.Color;
+  primaryDark: Property.Color;
+
+  alert: Property.Color;
+  info: Property.Color;
+  success: Property.Color;
+  warning: Property.Color;
+  error: Property.Color;
+
+  black: Property.Color;
+  white: Property.Color;
+  offWhite: Property.Color;
+  background: Property.Color;
+  gray100: Property.Color;
+  gray200: Property.Color;
+  gray300: Property.Color;
+  gray400: Property.Color;
+};
+```
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const App = () => {
 };
 ```
 
-아래 인터페이스 중 일부를 재정의한 객체를 `themeColor` props로 전달해 테마 컬러를 변경할 수 있습니다.
+아래 인터페이스 중 일부를 재정의한 객체를 `CdsProvider`의 `themeColor` props로 전달해 테마 컬러를 변경할 수 있습니다.
 
 ```tsx
 type ColorSet = {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 일관적인 UI 디자인과 접근성을 고려한 사용자 인터랙션을 제공합니다.
 
-[Storybook 문서](https://640054c53834f08f15bbad68-gkurucdpms.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인해보세요.
+[Storybook 문서](https://640054c53834f08f15bbad68-sscshdmgyf.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인할 수 있습니다.
 
 <!-- ## Table of contents
 - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 일관적인 UI 디자인과 접근성을 고려한 사용자 인터랙션을 제공합니다.
 
+[Storybook 문서](https://640054c53834f08f15bbad68-gkurucdpms.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인해보세요.
+
 <!-- ## Table of contents
 - [Usage](#usage)
 - [Documentation](#documentation)
@@ -19,13 +21,9 @@ npm install @chwh/cds
 yarn add @chwh/cds
 ```
 
-## Documentation
-
-[Storybook 문서](https://640054c53834f08f15bbad68-gkurucdpms.chromatic.com/) 에서 제공하는 컴포넌트의 종류와 용례를 확인해보세요.
-
 ## Usage
 
-사용을 위해 상위 컴포넌트를 `CdsProvider`로 감싸야 합니다.
+⚠️ 사용을 위해 상위 컴포넌트를 `CdsProvider`로 감싸야 합니다.
 
 ```tsx
 const App = () => {
@@ -37,7 +35,7 @@ const App = () => {
 };
 ```
 
-아래 인터페이스 중 일부를 재정의한 객체를 `CdsProvider`의 `themeColor` props로 전달해 테마 컬러를 변경할 수 있습니다.
+💅 아래 인터페이스 중 일부를 재정의한 객체를 `CdsProvider`의 `themeColor` props로 전달해 테마 컬러를 변경할 수 있습니다.
 
 ```tsx
 type ColorSet = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chwh/cds",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "cold design system for React apps",
   "keywords": [
     "React",

--- a/src/@types/emotion.d.ts
+++ b/src/@types/emotion.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
 import '@emotion/react';
-import type { Theme as CdsTheme } from '@components-common/CdsProvider/theme';
+import type { Theme as CdsTheme } from '@components-common/CdsProvider';
 
 declare module '@emotion/react' {
   export interface Theme extends CdsTheme {}

--- a/src/components/@common/CdsProvider/index.tsx
+++ b/src/components/@common/CdsProvider/index.tsx
@@ -1,4 +1,5 @@
 import Global from '@components-common/Global';
+import { COLOR, Color } from '@constants/color';
 import {
   DRAWER_PORTAL_ROOT_ID,
   TOAST_PORTAL_ROOT_ID,
@@ -7,17 +8,25 @@ import {
 import { ThemeProvider } from '@emotion/react';
 import { ReactNode } from 'react';
 
-import { theme } from './theme';
-
 interface CdsProviderProps {
+  themeColor: Color;
   children: ReactNode;
 }
 
-const CdsProvider = ({ children }: CdsProviderProps) => {
+export interface Theme {
+  color: Color;
+}
+
+const CdsProvider = ({ themeColor, children }: CdsProviderProps) => {
+  const color = {
+    ...COLOR,
+    ...themeColor,
+  };
+
   return (
     <>
       <Global />
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={{ color }}>
         {children}
         <div id={DRAWER_PORTAL_ROOT_ID}></div>
         <div id={TOAST_PORTAL_ROOT_ID}></div>

--- a/src/components/@common/CdsProvider/index.tsx
+++ b/src/components/@common/CdsProvider/index.tsx
@@ -1,5 +1,5 @@
 import Global from '@components-common/Global';
-import { COLOR, Color } from '@constants/color';
+import { COLOR, ColorSet } from '@constants/color';
 import {
   DRAWER_PORTAL_ROOT_ID,
   TOAST_PORTAL_ROOT_ID,
@@ -9,12 +9,12 @@ import { ThemeProvider } from '@emotion/react';
 import { ReactNode } from 'react';
 
 interface CdsProviderProps {
-  themeColor: Partial<Color>;
+  themeColor: Partial<ColorSet>;
   children: ReactNode;
 }
 
 export interface Theme {
-  color: Color;
+  color: ColorSet;
 }
 
 const CdsProvider = ({ themeColor, children }: CdsProviderProps) => {

--- a/src/components/@common/CdsProvider/index.tsx
+++ b/src/components/@common/CdsProvider/index.tsx
@@ -9,7 +9,7 @@ import { ThemeProvider } from '@emotion/react';
 import { ReactNode } from 'react';
 
 interface CdsProviderProps {
-  themeColor: Partial<ColorSet>;
+  themeColor?: Partial<ColorSet>;
   children: ReactNode;
 }
 

--- a/src/components/@common/CdsProvider/index.tsx
+++ b/src/components/@common/CdsProvider/index.tsx
@@ -9,7 +9,7 @@ import { ThemeProvider } from '@emotion/react';
 import { ReactNode } from 'react';
 
 interface CdsProviderProps {
-  themeColor: Color;
+  themeColor: Partial<Color>;
   children: ReactNode;
 }
 

--- a/src/components/@common/CdsProvider/theme.ts
+++ b/src/components/@common/CdsProvider/theme.ts
@@ -1,9 +1,0 @@
-import { COLOR } from '@constants/color';
-
-export interface Theme {
-  color: typeof COLOR;
-}
-
-export const theme: Theme = {
-  color: COLOR,
-} as const;

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,5 +1,5 @@
-import { theme } from '@components/@common/CdsProvider/theme';
 import Center from '@components-layout/Center';
+import { COLOR } from '@constants/color';
 import styled from '@emotion/styled';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
@@ -31,7 +31,7 @@ export default {
   args: {
     size: '16px',
     disabled: false,
-    color: theme.color.primary,
+    color: COLOR.primary,
     clickableSize: '30px',
     direction: 'right',
   },
@@ -54,7 +54,7 @@ export default {
       description: '기본 버튼의 색상을 지정합니다.',
       table: {
         type: { summary: "CSSProperties['color']" },
-        defaultValue: { summary: 'theme.primary' },
+        defaultValue: { summary: 'theme.color.primary' },
       },
       control: {
         type: 'color',

--- a/src/components/Slider/index.tsx
+++ b/src/components/Slider/index.tsx
@@ -1,7 +1,6 @@
-import { theme } from '@components/@common/CdsProvider/theme';
 import Flexbox from '@components/@layout/Flexbox';
 import Typography from '@components/Typography';
-import { css } from '@emotion/react';
+import { css, useTheme } from '@emotion/react';
 import {
   createContext,
   ReactNode,
@@ -91,7 +90,7 @@ interface TrackProps {
 const Track = ({ color, children }: TrackProps) => {
   const { label, trackRef, getStyles, onMoveSlider } =
     useSafeContext(SliderContext);
-  const { color: themeColor } = theme;
+  const { color: themeColor } = useTheme();
   const { gray100 } = themeColor;
   const { trackStyle } = getStyles();
 
@@ -119,7 +118,7 @@ interface FilledProps {
 
 const Filled = ({ color }: FilledProps) => {
   const { label, filledRef, getStyles } = useSafeContext(SliderContext);
-  const { color: themeColor } = theme;
+  const { color: themeColor } = useTheme();
   const { primary } = themeColor;
   const { filledStyle } = getStyles();
 
@@ -156,7 +155,7 @@ const Thumb = ({ color, children }: ThumbProps) => {
     onPressArrow,
   } = useSafeContext(SliderContext);
   const [isDraggable, setIsDraggable] = useState<boolean>(false);
-  const { color: themeColor } = theme;
+  const { color: themeColor } = useTheme();
   const { primary, white } = themeColor;
   const { thumbStyle } = getStyles();
 

--- a/src/components/Toast/ToastCore.tsx
+++ b/src/components/Toast/ToastCore.tsx
@@ -1,4 +1,3 @@
-import { theme } from '@components/@common/CdsProvider/theme';
 import Flexbox from '@components/@layout/Flexbox';
 import Typography from '@components/Typography';
 import {
@@ -10,7 +9,7 @@ import {
   MAIN_ICON_SIZE,
   CLOSE_ICON_SIZE,
 } from '@constants/toast';
-import { css, keyframes } from '@emotion/react';
+import { css, keyframes, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import { DefaultProps } from '@utils/types/DefaultProps';
 import { useEffect } from 'react';
@@ -42,7 +41,7 @@ const ToastCore = ({
   open,
   onClose,
 }: ToastProps) => {
-  const { color: themeColor } = theme;
+  const { color: themeColor } = useTheme();
   const { white } = themeColor;
 
   useEffect(() => {

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -20,7 +20,7 @@ export const COLOR = {
   gray200: '#CFD6DD',
   gray300: '#9EA8B3',
   gray400: '#555F6D',
-};
+} as const;
 
 type Color = Exclude<CSSProperties['color'], undefined>;
 

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -18,6 +18,6 @@ export const COLOR = {
   gray200: '#CFD6DD',
   gray300: '#9EA8B3',
   gray400: '#555F6D',
-} as const;
+};
 
 export type Color = typeof COLOR;

--- a/src/constants/color.ts
+++ b/src/constants/color.ts
@@ -1,3 +1,5 @@
+import { CSSProperties } from 'react';
+
 export const COLOR = {
   primary: '#1493FF',
   primaryLight: '#66B9FF',
@@ -20,4 +22,8 @@ export const COLOR = {
   gray400: '#555F6D',
 };
 
-export type Color = typeof COLOR;
+type Color = Exclude<CSSProperties['color'], undefined>;
+
+export type ColorSet = {
+  [P in keyof typeof COLOR]: Color;
+};

--- a/src/styles/dimmed.ts
+++ b/src/styles/dimmed.ts
@@ -1,15 +1,10 @@
-import { Color } from '@constants/color';
+import { ColorSet } from '@constants/color';
 import { css } from '@emotion/react';
 import { CSSProperties } from 'react';
 
-/**
- * @param {CSSProperties['position']} position
- * @param {Color} {black}
- * @returns {SerializedStyles}
- */
 export const dimmerStyle = (
   position: CSSProperties['position'],
-  { black }: Color,
+  { black }: ColorSet,
 ) => css`
   position: ${position};
   top: 0;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes #118

- CdsProvider에 themeColor props를 전달해 테마 색상을 커스텀 할 수 있도록 합니다.

## 💫 설명

<!--

- 현재 Pr 설명

-->

- publish는 리뷰 끝나면 하겠습니다.

- 개발 시점에 자동완성 지원합니다!
  <img width="759" alt="image" src="https://user-images.githubusercontent.com/63814960/234189668-06929cca-d9b6-4647-80e3-2dd5659659a4.png">

## 📷 스크린샷 (Optional)
