### PR TITLE
config: PR Reviewer Auto Assign CI

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,9 @@
+addReviewers: true
+addAssignees: author
+reviewers:
+  - prayinforrain
+  - iyu88
+  - se030
+  - leesunmin1231
+  - dohun31
+numberOfReviewers: 0

--- a/.github/workflows/review-auto-assign.yml
+++ b/.github/workflows/review-auto-assign.yml
@@ -1,0 +1,14 @@
+name: 'Review Auto Assign'
+
+on:
+  pull_request:
+    branches: ['main']
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/auto-assign.yml'


### PR DESCRIPTION
## 🤠 개요

- #45 
- PR 올릴 때 자동으로 리뷰어가 지정되도록 CI 설정을 진행합니다.

## 💫 설명

- [이 GitHub Actions](https://github.com/kentaro-m/auto-assign-action)를 추가했습니다.
- 설정해보고 적용 안되면 main 브랜치에서 수정해보도록 하겠습니다 😅
