### PR TITLE
Test/ Slider component interaction test

### DIFF
--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -43,5 +43,15 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '100');
       shouldBeEqualPercentage('width', 'left');
     });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '51');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '49');
+    });
   });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -144,4 +144,64 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '100');
     });
   });
+
+  describe('Max Value Variant slider', () => {
+    beforeEach(() => {
+      initAlias('max-value-variant');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Click min value', () => {
+      cy.get('@track').click('left');
+      cy.get('@thumb').invoke('text').should('eq', '50');
+    });
+
+    it('Click max value', () => {
+      cy.get('@track').click('right');
+      cy.get('@thumb').invoke('text').should('eq', '200');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '101');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '101');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '99');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '99');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '115');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '85');
+    });
+
+    it('Set min with home key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 36 });
+      cy.get('@thumb').invoke('text').should('eq', '50');
+    });
+
+    it('Set max with end key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 35 });
+      cy.get('@thumb').invoke('text').should('eq', '200');
+    });
+  });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -1,14 +1,15 @@
-const SLIDER_TRACK_ID = '#cds_Slider-slider-track';
-const SLIDER_FILLED_ID = '#cds_Slider-slider-filled';
-const SLIDER_THUMB_ID = '#cds_Slider-slider-thumb';
+const SLIDER_PREFIX = '#cds_Slider-slider';
+const TRACK_ID = `${SLIDER_PREFIX}-track`;
+const FILLED_ID = `${SLIDER_PREFIX}-filled`;
+const THUMB_ID = `${SLIDER_PREFIX}-thumb`;
 
 describe('Slider component test', () => {
   beforeEach(() => {
     cy.visitStory('components-slider');
     cy.getStory('slider', 'default').as('slider');
-    cy.get('@slider').find(SLIDER_TRACK_ID).as('track');
-    cy.get('@slider').find(SLIDER_FILLED_ID).as('filled');
-    cy.get('@slider').find(SLIDER_THUMB_ID).as('thumb');
+    cy.get('@slider').find(TRACK_ID).as('track');
+    cy.get('@slider').find(FILLED_ID).as('filled');
+    cy.get('@slider').find(THUMB_ID).as('thumb');
   });
 
   describe('Default slider', () => {

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -84,4 +84,64 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '100');
     });
   });
+
+  describe('Min Value Variant slider', () => {
+    beforeEach(() => {
+      initAlias('min-value-variant');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Click min value', () => {
+      cy.get('@track').click('left');
+      cy.get('@thumb').invoke('text').should('eq', '50');
+    });
+
+    it('Click max value', () => {
+      cy.get('@track').click('right');
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '76');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '76');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '74');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '74');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '80');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '70');
+    });
+
+    it('Set min with home key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 36 });
+      cy.get('@thumb').invoke('text').should('eq', '50');
+    });
+
+    it('Set max with end key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 35 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+  });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -11,6 +11,18 @@ describe('Slider component test', () => {
     cy.get('@slider').find(THUMB_ID).as('thumb');
   }
 
+  const shouldBeEqualPercentage = (dimension: FilledDimension, position: ThumbPosition) => {
+    cy.get('@filled')
+      .invoke('css', dimension)
+      .then(dimensionPercentage => {
+        cy.get('@thumb')
+          .invoke('css', position)
+          .then(positionPercentage => {
+            expect(dimensionPercentage).equal(positionPercentage);
+        });
+      });
+  }
+
   beforeEach(() => {
     cy.visitStory('components-slider');
   });
@@ -22,12 +34,14 @@ describe('Slider component test', () => {
 
     it('Click min value', () => {
       cy.get('@track').click('left');
-      cy.get('@thumb').invoke('text').should('eq', '0');  
+      cy.get('@thumb').invoke('text').should('eq', '0');
+      shouldBeEqualPercentage('width', 'left');
     });
 
     it('Click max value', () => {
       cy.get('@track').click('right');
-      cy.get('@thumb').invoke('text').should('eq', '100');  
+      cy.get('@thumb').invoke('text').should('eq', '100');
+      shouldBeEqualPercentage('width', 'left');
     });
   });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -12,15 +12,13 @@ describe('Slider component test', () => {
   }
 
   const shouldBeEqualPercentage = (dimension: FilledDimension, position: ThumbPosition) => {
-    cy.get('@filled')
-      .invoke('css', dimension)
-      .then(dimensionPercentage => {
-        cy.get('@thumb')
-          .invoke('css', position)
-          .then(positionPercentage => {
-            expect(dimensionPercentage).equal(positionPercentage);
-        });
+    cy.get('@filled').then(([ filledElement ]) => {
+      cy.get('@thumb').then(([ thumbElement ]) => {
+        const filledStyle = window.getComputedStyle(filledElement)[dimension];
+        const thumbStyle = window.getComputedStyle(thumbElement)[position];
+        expect(filledStyle).equal(thumbStyle);
       });
+    });
   }
 
   beforeEach(() => {

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -334,4 +334,64 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '40');
     });
   });
+
+  describe('With Vertical Orientation slider', () => {
+    beforeEach(() => {
+      initAlias('with-vertical-orientation');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('height', 'bottom');
+    });
+
+    it('Click min value', () => {
+      cy.get('@track').click(0, 200, { force: true });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+
+    it('Click max value', () => {
+      cy.get('@track').click('top');
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '51');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '51');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '49');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '49');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
+
+    it('Set min with home key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 36 });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+
+    it('Set max with end key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 35 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+  });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -1,0 +1,25 @@
+const SLIDER_TRACK_ID = '#cds_Slider-slider-track';
+const SLIDER_FILLED_ID = '#cds_Slider-slider-filled';
+const SLIDER_THUMB_ID = '#cds_Slider-slider-thumb';
+
+describe('Slider component test', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:6006/?path=/docs/components-slider--default');
+    cy.getStory('slider', 'default').as('slider');
+    cy.get('@slider').find(SLIDER_TRACK_ID).as('track');
+    cy.get('@slider').find(SLIDER_FILLED_ID).as('filled');
+    cy.get('@slider').find(SLIDER_THUMB_ID).as('thumb');
+  });
+
+  describe('Default slider', () => {
+    it('Click min value', () => {
+      cy.get('@track').click('left');
+      cy.get('@thumb').invoke('text').should('eq', '0');  
+    });
+
+    it('Click max value', () => {
+      cy.get('@track').click('right');
+      cy.get('@thumb').invoke('text').should('eq', '100');  
+    });
+  });
+});

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -4,15 +4,22 @@ const FILLED_ID = `${SLIDER_PREFIX}-filled`;
 const THUMB_ID = `${SLIDER_PREFIX}-thumb`;
 
 describe('Slider component test', () => {
-  beforeEach(() => {
-    cy.visitStory('components-slider');
-    cy.getStory('slider', 'default').as('slider');
+  const initAlias = (storyName: string) => {
+    cy.getStory('slider', storyName).as('slider');
     cy.get('@slider').find(TRACK_ID).as('track');
     cy.get('@slider').find(FILLED_ID).as('filled');
     cy.get('@slider').find(THUMB_ID).as('thumb');
+  }
+
+  beforeEach(() => {
+    cy.visitStory('components-slider');
   });
 
   describe('Default slider', () => {
+    beforeEach(() => {
+      initAlias('default');
+    })
+
     it('Click min value', () => {
       cy.get('@track').click('left');
       cy.get('@thumb').invoke('text').should('eq', '0');  

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -85,6 +85,56 @@ describe('Slider component test', () => {
     });
   });
 
+  describe('Start From Zero slider', () => {
+    beforeEach(() => {
+      initAlias('start-from-zero');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+  });
+
+  describe('Start From End slider', () => {
+    beforeEach(() => {
+      initAlias('start-from-end');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
+  });
+
   describe('Min Value Variant slider', () => {
     beforeEach(() => {
       initAlias('min-value-variant');

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -204,4 +204,84 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '200');
     });
   });
+
+  describe('With Step 10 slider', () => {
+    beforeEach(() => {
+      initAlias('with-step-10');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
+  });
+
+  describe('With Step 20 slider', () => {
+    beforeEach(() => {
+      initAlias('with-step-20');
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
+
+    it('Increase with right arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 39 });
+      cy.get('@thumb').invoke('text').should('eq', '70');
+    });
+
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '70');
+    });
+
+    it('Decrease with left arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '30');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
+      cy.get('@thumb').invoke('text').should('eq', '30');
+    });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
+  });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -73,5 +73,15 @@ describe('Slider component test', () => {
       cy.get("@thumb").trigger('keydown', { keyCode : 34 });
       cy.get('@thumb').invoke('text').should('eq', '40');
     });
+
+    it('Set min with home key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 36 });
+      cy.get('@thumb').invoke('text').should('eq', '0');
+    });
+
+    it('Set max with end key', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 35 });
+      cy.get('@thumb').invoke('text').should('eq', '100');
+    });
   });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -63,5 +63,15 @@ describe('Slider component test', () => {
       cy.get("@thumb").trigger('keydown', { keyCode : 40 });
       cy.get('@thumb').invoke('text').should('eq', '49');
     });
+
+    it('Increase with page up', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 33 });
+      cy.get('@thumb').invoke('text').should('eq', '60');
+    });
+
+    it('Decrease with page down', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 34 });
+      cy.get('@thumb').invoke('text').should('eq', '40');
+    });
   });
 });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -4,7 +4,7 @@ const SLIDER_THUMB_ID = '#cds_Slider-slider-thumb';
 
 describe('Slider component test', () => {
   beforeEach(() => {
-    cy.visit('http://localhost:6006/?path=/docs/components-slider--default');
+    cy.visitStory('components-slider');
     cy.getStory('slider', 'default').as('slider');
     cy.get('@slider').find(SLIDER_TRACK_ID).as('track');
     cy.get('@slider').find(SLIDER_FILLED_ID).as('filled');

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -4,11 +4,11 @@ const FILLED_ID = `${SLIDER_PREFIX}-filled`;
 const THUMB_ID = `${SLIDER_PREFIX}-thumb`;
 
 describe('Slider component test', () => {
-  const initAlias = (storyName: string) => {
-    cy.getStory('slider', storyName).as('slider');
-    cy.get('@slider').find(TRACK_ID).as('track');
-    cy.get('@slider').find(FILLED_ID).as('filled');
-    cy.get('@slider').find(THUMB_ID).as('thumb');
+  const initAlias = () => {
+    cy.get('#root').as('root');
+    cy.get('@root').find(TRACK_ID).as('track');
+    cy.get('@root').find(FILLED_ID).as('filled');
+    cy.get('@root').find(THUMB_ID).as('thumb');
   }
 
   const shouldBeEqualPercentage = (dimension: FilledDimension, position: ThumbPosition) => {
@@ -21,13 +21,10 @@ describe('Slider component test', () => {
     });
   }
 
-  beforeEach(() => {
-    cy.visitStory('components-slider');
-  });
-
   describe('Default slider', () => {
     beforeEach(() => {
-      initAlias('default');
+      cy.visitStory('slider', 'default');
+      initAlias();
     });
 
     afterEach(() => {
@@ -87,7 +84,8 @@ describe('Slider component test', () => {
 
   describe('Start From Zero slider', () => {
     beforeEach(() => {
-      initAlias('start-from-zero');
+      cy.visitStory('slider', 'start-from-zero');
+      initAlias();
     });
 
     afterEach(() => {
@@ -112,7 +110,8 @@ describe('Slider component test', () => {
 
   describe('Start From End slider', () => {
     beforeEach(() => {
-      initAlias('start-from-end');
+      cy.visitStory('slider', 'start-from-end');
+      initAlias();
     });
 
     afterEach(() => {
@@ -137,7 +136,8 @@ describe('Slider component test', () => {
 
   describe('Min Value Variant slider', () => {
     beforeEach(() => {
-      initAlias('min-value-variant');
+      cy.visitStory('slider', 'min-value-variant');
+      initAlias();
     });
 
     afterEach(() => {
@@ -197,7 +197,8 @@ describe('Slider component test', () => {
 
   describe('Max Value Variant slider', () => {
     beforeEach(() => {
-      initAlias('max-value-variant');
+      cy.visitStory('slider', 'max-value-variant');
+      initAlias();
     });
 
     afterEach(() => {
@@ -257,7 +258,8 @@ describe('Slider component test', () => {
 
   describe('With Step 10 slider', () => {
     beforeEach(() => {
-      initAlias('with-step-10');
+      cy.visitStory('slider', 'with-step-10');
+      initAlias();
     });
 
     afterEach(() => {
@@ -297,7 +299,8 @@ describe('Slider component test', () => {
 
   describe('With Step 20 slider', () => {
     beforeEach(() => {
-      initAlias('with-step-20');
+      cy.visitStory('slider', 'with-step-20');
+      initAlias();
     });
 
     afterEach(() => {
@@ -337,7 +340,8 @@ describe('Slider component test', () => {
 
   describe('With Vertical Orientation slider', () => {
     beforeEach(() => {
-      initAlias('with-vertical-orientation');
+      cy.visitStory('slider', 'with-vertical-orientation');
+      initAlias();
     });
 
     afterEach(() => {

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -49,8 +49,18 @@ describe('Slider component test', () => {
       cy.get('@thumb').invoke('text').should('eq', '51');
     });
 
+    it('Increase with up arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 38 });
+      cy.get('@thumb').invoke('text').should('eq', '51');
+    });
+
     it('Decrease with left arrow', () => {
       cy.get("@thumb").trigger('keydown', { keyCode : 37 });
+      cy.get('@thumb').invoke('text').should('eq', '49');
+    });
+
+    it('Decrease with down arrow', () => {
+      cy.get("@thumb").trigger('keydown', { keyCode : 40 });
       cy.get('@thumb').invoke('text').should('eq', '49');
     });
   });

--- a/cypress/e2e/components/slider.cy.ts
+++ b/cypress/e2e/components/slider.cy.ts
@@ -30,18 +30,20 @@ describe('Slider component test', () => {
   describe('Default slider', () => {
     beforeEach(() => {
       initAlias('default');
-    })
+    });
+
+    afterEach(() => {
+      shouldBeEqualPercentage('width', 'left');
+    });
 
     it('Click min value', () => {
       cy.get('@track').click('left');
       cy.get('@thumb').invoke('text').should('eq', '0');
-      shouldBeEqualPercentage('width', 'left');
     });
 
     it('Click max value', () => {
       cy.get('@track').click('right');
       cy.get('@thumb').invoke('text').should('eq', '100');
-      shouldBeEqualPercentage('width', 'left');
     });
 
     it('Increase with right arrow', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,9 +1,5 @@
 /// <reference types="cypress" />
 
-Cypress.Commands.add("visitStory", (path) => {
-  cy.visit(`http://localhost:6006/?path=/docs/${path}`);
-})
-
-Cypress.Commands.add("getStory", (componentName, storyName) => {
-  return cy.get("#storybook-preview-iframe").its('0.contentDocument.body').should('not.be.empty').then(body => cy.wrap(body).find(`#story--components-${componentName}--${storyName}`));
+Cypress.Commands.add("visitStory", (componentName, storyName) => {
+  cy.visit(`http://localhost:6006/iframe.html?id=components-${componentName}--${storyName}&viewMode=story`)
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,9 @@
 /// <reference types="cypress" />
 
+Cypress.Commands.add("visitStory", (path) => {
+  cy.visit(`http://localhost:6006/?path=/docs/${path}`);
+})
+
 Cypress.Commands.add("getStory", (componentName, storyName) => {
   return cy.get("#storybook-preview-iframe").its('0.contentDocument.body').should('not.be.empty').then(body => cy.wrap(body).find(`#story--components-${componentName}--${storyName}`));
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,37 +1,5 @@
 /// <reference types="cypress" />
-// ***********************************************
-// This example commands.ts shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-//
-// declare global {
-//   namespace Cypress {
-//     interface Chainable {
-//       login(email: string, password: string): Chainable<void>
-//       drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
-//       visit(originalFn: CommandOriginalFn, url: string, options: Partial<VisitOptions>): Chainable<Element>
-//     }
-//   }
-// }
+
+Cypress.Commands.add("getStory", (componentName, storyName) => {
+  return cy.get("#storybook-preview-iframe").its('0.contentDocument.body').should('not.be.empty').then(body => cy.wrap(body).find(`#story--components-${componentName}--${storyName}`));
+})

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,5 +1,6 @@
 declare namespace Cypress {
   interface Chainable {
+    visitStory(path: string): void,
     getStory(componentName: string, storyName: string): Chainable<JQuery<HTMLElement>>
   }
 }

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -4,3 +4,6 @@ declare namespace Cypress {
     getStory(componentName: string, storyName: string): Chainable<JQuery<HTMLElement>>
   }
 }
+
+type FilledDimension = 'width' | 'height';
+type ThumbPosition = 'left' | 'bottom';

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,5 @@
+declare namespace Cypress {
+  interface Chainable {
+    getStory(componentName: string, storyName: string): Chainable<JQuery<HTMLElement>>
+  }
+}

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,7 +1,6 @@
 declare namespace Cypress {
   interface Chainable {
-    visitStory(path: string): void,
-    getStory(componentName: string, storyName: string): Chainable<JQuery<HTMLElement>>
+    visitStory(componentName: string, storyName: string): void,
   }
 }
 


### PR DESCRIPTION
## 🤠 개요

- #128 
- Slider 컴포넌트 스토리에 대해서 E2E 테스트를 진행합니다.

## 💫 설명

- Storybook으로 작성한 Slider 컴포넌트의 각 스토리에 E2E 테스트 코드를 작성했습니다. 

- `Default slider`에 대한 테스트 코드를 기준으로 설명드리면,

  - 🐭 마우스 이벤트

  1. Click min value : slider track의 가장 왼쪽 혹은 아래쪽을 클릭했을 때 최솟값으로 설정되는지

  2. Click max value : slider track의 가장 오른쪽 혹은 위쪽을 클릭했을 때 최댓값으로 설정되는지

  - 🎹 키보드 이벤트

  3. Increase with right arrow : ➡️ key를 한번 눌렀을 때, 1 (step) 만큼 증가하는지

  4. Increase with up arrow : ⬆️ key를 한번 눌렀을 때, 1 (step) 만큼 증가하는지

  5. Decrease with left arrow : ⬅️ key를 한번 눌렀을 때, 1 (step) 만큼 감소하는지

  6. Decrease with down arrow : ⬇️ key를 한번 눌렀을 때, 1 (step) 만큼 감소하는지

  7. Increase with page up : `PageUp key`를 눌렀을 때, 10% 증가하는지

  8. Decrease with page down : `PageDown key`를 눌렀을 때, 10% 감소하는지

  9. Set min with home key : `Home key`를 눌렀을 때, 최솟값으로 설정되는지

  10. Set max with end key : `End key`를 눌렀을 때, 최댓값으로 설정되는지

- 그 외의 스토리에 대해서는 필요하다고 판단한 테스트 케이스만 추가했습니다. 

- 추상화하지 않는 것이 테스트를 읽는 것에 더 도움이 될 것이라고 판단하여 일부러 반복되는 부분을 남겨둔 점도 있습니다.

- cypress/support/commands.ts 파일에 `커스텀 커맨드`를 정의했습니다. 
  
  *커스텀 커맨드
  Cypress에서 제공하는 커맨드(메서드)를 조합해서 커스텀할 수 있습니다. 
  Chaining해서 사용할 수 있는 함수를 정의했다고 보시면 될 것 같습니다. 

- cypress/support/index.d.ts 파일에 커스텀 커맨드 및 기타 함수에서 사용할 타입을 정의했습니다.

## 📷 스크린샷 (Optional)

➡️ 58개의 테스트를 작성했습니다.
<img width="534" alt="스크린샷 2023-05-30 22 27 47" src="https://github.com/c-h-w-h/cds/assets/31645195/33719fae-6314-4453-97b6-43b439a8f194">
